### PR TITLE
fix: jp locale in tutorial

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -1792,10 +1792,10 @@
 
         "CloudHome.AvatarPanel.Title": "アバターワールド特集",
 
-        "CloudHome.SupporterPanel.Title": "<b>支援してくださった皆様</b>",
+        "CloudHome.SupporterPanel.Title": "<b>支援者の一覧</b>",
 
         "Tutorial.InfoPanel.Title": "最後に……",
-        "Tutorial.InfoPanel.Content": "  この可能性に満ち溢れた世界を動かす原動力、それはあなたの想像力に他なりません。<br><br>  このワールドのほとんどのモノ・ギミックは、世界中の人々がResoniteの中で（！）リアルタイムの協働作業で作りました。<br><br>  このプラットフォームはまだ開発途上であり、常時改善し更新を行っています。 この長い長い旅路がやがてどこまで至るのか見届けるのは、あなたです。<br><br><align=center>訪れてくださった皆様に、特別な感謝を。Resoniteをぜひお楽しみください。</align>",
+        "Tutorial.InfoPanel.Content": "     この可能性に満ち溢れた世界を動かす原動力、それは<br>あなたの想像力に他なりません。<br>      このワールドのほとんどのモノ・ギミックは、世界中の人々がResoniteの中で（！）リアルタイムの協働作業で作った物です。<br><br><br>  Resoniteは開発途上であり、常時改善し更新を行っています。 この長い長い旅路がやがてどこまで至るのか見届けるのは、あなたです。<br><br><align=center>訪れた皆様に特別な感謝を。Resoniteをお楽しみください。</align>",
 
         "Tutorial.GrabItems.Grab": "グラブ",
         "Tutorial.GrabItems.Snap": "スナップ",
@@ -1852,7 +1852,7 @@
         "Hints.Sundial.TheSun": "太陽を動かそう！ 狙った方向に動くぞ！",
         "Hints.Sundial.TheSunExtra": "太陽が沈むと夜になります。",
 
-        "Hints.Sundial.Dequip": "コンテキストメニューを開いて「装備を外す」 からツールを手放せます。 ",
+        "Hints.Sundial.Dequip": "コンテキストメニューを開いて<br>「装備を外す」 からツールを手放せます。 ",
         "Hints.Sundial.DequipExtra": "ツールを装備しているときは、 コンテキストメニューの内容が変化します。",
 
         "Hints.Sundial.Teleporter": "テレポーターを起動して クラウドホームに移動しよう！",

--- a/ja.json
+++ b/ja.json
@@ -1792,71 +1792,71 @@
 
         "CloudHome.AvatarPanel.Title": "アバターワールド特集",
 
-        "CloudHome.SupporterPanel.Title": "<b>サポーター一覧</b>",
+        "CloudHome.SupporterPanel.Title": "<b>支援してくださった皆様</b>",
 
-        "Tutorial.InfoPanel.Title": "おっと！その前に",
-        "Tutorial.InfoPanel.Content": "可能性に満ちた世界が待っています！ あなたの想像力次第でなんでもできます！<br><br>これまでに見たもののほとんどはこのゲーム内で作られました！ 世界中の人々が協力してこのプラットフォームを作ったんです。<br><br>このプラットフォームは開発の初期段階にあり、常に改善と更新を行っています。 あなたも一緒に旅に出ましょう！この旅に限界は無い！<br><br><align=center>お立ち寄りいただきありがとうございました。</align>",
+        "Tutorial.InfoPanel.Title": "最後に……",
+        "Tutorial.InfoPanel.Content": "  この可能性に満ち溢れた世界を動かす原動力、それはあなたの想像力に他なりません。<br><br>  このワールドのほとんどのモノ・ギミックは、世界中の人々がResoniteの中で（！）リアルタイムの協働作業で作りました。<br><br>  このプラットフォームはまだ開発途上であり、常時改善し更新を行っています。 この長い長い旅路がやがてどこまで至るのか見届けるのは、あなたです。<br><br><align=center>訪れてくださった皆様に、特別な感謝を。Resoniteをぜひお楽しみください。</align>",
 
         "Tutorial.GrabItems.Grab": "グラブ",
         "Tutorial.GrabItems.Snap": "スナップ",
         "Tutorial.GrabItems.Slide": "スライド",
 
         "Tutorial.Panel.Jumping.Title": "ジャンプ",
-        "Tutorial.Panel.Jumping.ContentDesktop": "歩行中にスペースキーでジャンプ！",
-        "Tutorial.Panel.Jumping.ContentVR": "歩行中にスティック 押し込みでジャンプ！",
-        "Tutorial.Panel.Jumping.ContentVRNoButtons": "歩行中にタッチパッド中央を押すとジャンプ！",
+        "Tutorial.Panel.Jumping.ContentDesktop": "スペースキーでジャンプ！",
+        "Tutorial.Panel.Jumping.ContentVR": "スティック押し込みでジャンプ！",
+        "Tutorial.Panel.Jumping.ContentVRNoButtons": "タッチパッド中央を押すとジャンプ！",
 
         "Tutorial.Panel.WalkLocomotion.Title": "歩行 ロコモーション",
-        "Tutorial.Panel.WalkLocomotion.Content": "地面を歩いたりジャンプしたりする。",
+        "Tutorial.Panel.WalkLocomotion.Content": "地面を歩行する移動方法。 ジャンプなどができます。",
 
         "Tutorial.Panel.TeleportLocomotion.Title": "テレポート ロコモーション",
-        "Tutorial.Panel.TeleportLocomotion.Content": "指定した地点に テレポートする。",
+        "Tutorial.Panel.TeleportLocomotion.Content": "狙った地点に テレポートします。",
 
-        "Hints.Spawn.InitialMovementDesktop": "移動キーで 歩きまわろう！",
-        "Hints.Spawn.InitialMovementVR": "スティックで 歩きまわろう！",
+        "Hints.Spawn.InitialMovementDesktop": "WASDキーで移動しよう！",
+        "Hints.Spawn.InitialMovementVR": "スティックを倒して歩こう！",
         "Hints.Spawn.InitialMovementVRNoButtons": "タッチパッドで歩きまわろう！",
 
-        "Hints.Spawn.ContextMenuDesktop": "Tキーで コンテキストメニューを開く！",
-        "Hints.Spawn.ContextMenuVR": "BまたはYボタンで コンテキストメニューを開く！",
-        "Hints.Spawn.ContextMenuVRNoButtons": "メニューボタンでコンテキストメニューを開く！",
+        "Hints.Spawn.ContextMenuDesktop": "次に、Tキーを押してコンテキストメニューを開こう！",
+        "Hints.Spawn.ContextMenuVR": "次に、BボタンかYボタンでコンテキストメニューを開こう！",
+        "Hints.Spawn.ContextMenuVRNoButtons": "次に、メニューボタンでコンテキストメニューを開こう！",
 
-        "Hints.Spawn.TeleportLocomotionDesktop": "「移動方法」からフライなど、 他の移動方法を試せます。",
-        "Hints.Spawn.TeleportLocomotionVR": "「移動方法」から フライやテレポートなど、 他の移動方法を試せます。",
+        "Hints.Spawn.TeleportLocomotionDesktop": "「移動方法」からフライなどの、他の移動方法に変更できます！",
+        "Hints.Spawn.TeleportLocomotionVR": "「移動方法」から フライやテレポートなど、 他の移動方法に変更できます！",
 
-        "Hints.Bridge.RaiseTheWorld": "このボタンを押すとプラットフォームがこっちに来ます！",
+        "Hints.Bridge.RaiseTheWorld": "このボタンを押して先に進みましょう！",
 
         "Hints.Grabbing.GrabbingDesktop": "右クリック長押しで 物を掴む！",
-        "Hints.Grabbing.GrabbingVR": "グリップを握って 物を掴む！",
+        "Hints.Grabbing.GrabbingVR": "グリップボタンを握って 物を掴む！",
 
         "Hints.Grabbing.Rotating": "Eを押しながらマウスを動かすと、 持っているアイテムを回転できます！",
         "Hints.Grabbing.RotatingExtra": "Shift+Eを押しながらマウスを動かすと、 アイテムを水平に回転できます。",
 
-        "Hints.Grabbing.ScalingDesktop": "アイテムを持ちながらShiftを押し、 ホイールをスクロールすると 拡大縮小します！",
+        "Hints.Grabbing.ScalingDesktop": "アイテムを持ちながらShiftを押し、 ホイールをスクロールすると アイテムが拡大縮小します！",
         "Hints.Grabbing.ScalingVR": "両手でアイテムを引っ張ると大きさが変わります！",
 
-        "Hints.Grabbing.OtherGrabbables": "掴めるものにはいろいろ<br>種類があります。 3つの違いを試してみてください。",
-        "Hints.Grabbing.OtherGrabbablesExtraDesktop": "拡大縮小できるのはアイテムだけではありません。 コンテキストメニューでスケーリングを有効にして、 Ctrlを押しながらホイールをスクロールしてみましょう。 自分の大きさが変わります！",
-        "Hints.Grabbing.OtherGrabbablesExtraVR": "拡大縮小できるのはアイテムだけではありません。 コンテキストメニューでスケーリングを有効にして、 両手で何もないところを掴んでひっぱってみましょう。 自分の大きさが変わります！",
+        "Hints.Grabbing.OtherGrabbables": "掴めるものにはいくつか<br>種類があります。<br>ここに例があります。",
+        "Hints.Grabbing.OtherGrabbablesExtraDesktop": "アイテムだけでなく、自分自身も拡大縮小できます。 コンテキストメニューでスケーリングを有効にして、 Ctrlを押しながらホイールをスクロールしてみましょう。 ",
+        "Hints.Grabbing.OtherGrabbablesExtraVR": "アイテムだけでなく、自分自身も拡大縮小できます。 コンテキストメニューでスケーリングを有効にして、 両手で何もないところを掴んでひっぱってみましょう。",
 
-        "Hints.Telescope.Alignment": "望遠鏡を動かして月を見てみましょう！",
+        "Hints.Telescope.Alignment": "望遠鏡を動かして 月を見てみよう！",
 
-        "Hints.Telescope.TheMoonDesktop": "右クリックで月を掴んで動かしてみよう！",
+        "Hints.Telescope.TheMoonDesktop": "右クリックで月を掴んで 動かしてみよう！",
         "Hints.Telescope.TheMoonVR": "トリガーでレーザーを出し、 グリップで月を掴んで動かしてみよう！",
 
-        "Hints.Sundial.SoftEquip": "ツールを掴んで 使ってみよう！",
-        "Hints.Sundial.SoftEquipExtra": "ツールを使うと、 ワールドの環境を様々な形に変化させられます。",
+        "Hints.Sundial.SoftEquip": "ツールを掴んで 装備しよう！",
+        "Hints.Sundial.SoftEquipExtra": "ツールを利用して、 ワールドの環境を様々に変化させられます。",
 
-        "Hints.Sundial.HardEquip": "ツールをクリックして 装備しよう！",
-        "Hints.Sundial.HardEquipExtra": "レーザーが見えませんか？ トリガーを引くと出てきます。",
+        "Hints.Sundial.HardEquip": "このツールをクリックして 装備しよう！",
+        "Hints.Sundial.HardEquipExtra": "レーザーが見えない場合、 トリガーを引くと出てきます。",
 
-        "Hints.Sundial.TheSun": "空に向けてクリックすると太陽が移動します。",
-        "Hints.Sundial.TheSunExtra": "地平線の下を狙えば夜になります！",
+        "Hints.Sundial.TheSun": "太陽を動かそう！ 狙った方向に動くぞ！",
+        "Hints.Sundial.TheSunExtra": "太陽が沈むと夜になります。",
 
-        "Hints.Sundial.Dequip": "コンテキストメニューの 「装備を外す」で ツールを置きます。",
+        "Hints.Sundial.Dequip": "コンテキストメニューを開いて「装備を外す」 からツールを手放せます。 ",
         "Hints.Sundial.DequipExtra": "ツールを装備しているときは、 コンテキストメニューの内容が変化します。",
 
-        "Hints.Sundial.Teleporter": "このボタンを押して、 クラウドホームへのテレポーターを 起動しよう！",
-        "Hints.Sundial.TeleporterExtra": "あなた専用のお家でおくつろぎください！ お立ち寄りいただきありがとうございました。",
+        "Hints.Sundial.Teleporter": "テレポーターを起動して クラウドホームに移動しよう！",
+        "Hints.Sundial.TeleporterExtra": "第二の我が家、Resoniteをお楽しみください！",
 
         "UI.TextDisplay.Landscape": "横長",
         "UI.TextDisplay.Portrait": "縦長",


### PR DESCRIPTION
チュートリアルで見られる日本語の表現をなるべく自然なものに修正。

- ひとまず段落の頭の空白は半角スペース２個にしました。日本語翻訳ルールを定めたい。

@rabbuttz ねんのため