### PR TITLE
Update ja.json Inventory.Equip

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -108,7 +108,7 @@
         "Interaction.CopyLink": "リンクをコピー",
 
         "Inventory.OpenWorld": "ワールドを開く",
-        "Inventory.Equip": "装備",
+        "Inventory.Equip": "アバターを変更",
         "Inventory.Delete": "削除",
         "Inventory.SaveHeld": "アイテムを保存",
         "Inventory.Inventories": "インベントリー一覧",


### PR DESCRIPTION
現在`Inventory.Equip`はアバターにのみ使われていると認識しています。
日本語で"装備"という言葉はアバターに対して使われることはありません。
"アバターを着る"に変更しました。
これは`Interaction.EquipAvatar`でも使われています。

I understand that `Inventory.Equip` is currently used only for avatars.
In Japanese, the word "装備" is never used for avatars.
Changed to "アバターを着る".
This is also used in `Interaction.EquipAvatar`.