### PR TITLE
Add missing english key Inventory.CreateDirectory

### DIFF
--- a/en.json
+++ b/en.json
@@ -111,7 +111,7 @@
         "Inventory.OpenWorld": "Open World",
         "Inventory.Equip": "Equip",
         "Inventory.Delete": "Delete",
-	"Inventory.CreateDirectory": "Create folder",
+	    "Inventory.CreateDirectory": "Create folder",
         "Inventory.SaveHeld": "Save Held",
         "Inventory.Inventories": "Inventories",
         "Inventory.Share": "Share",

--- a/en.json
+++ b/en.json
@@ -111,6 +111,7 @@
         "Inventory.OpenWorld": "Open World",
         "Inventory.Equip": "Equip",
         "Inventory.Delete": "Delete",
+	"Inventory.CreateDirectory": "Create folder",
         "Inventory.SaveHeld": "Save Held",
         "Inventory.Inventories": "Inventories",
         "Inventory.Share": "Share",


### PR DESCRIPTION
Here is a fix for the missing key `Inventory.CreateDirectory`.

While the key state for `Directory` I feel that `folder` is more adapted here, at least for now, plus keep the text on one line.

I can change it to `directory` if needed.