### PR TITLE
ja: Optimizing Indicator.Sync.SyncingItems Display

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -387,7 +387,7 @@
         "Indicator.ServerStatus.NoInternet": "インターネットなし",
 
         "Indicator.Sync.AllSynced": "シンク完了",
-        "Indicator.Sync.SyncingItems": "{item_count,plural, other {# 個のアイテムを}}シンク中<nobr>({item_percent} %)",
+        "Indicator.Sync.SyncingItems": "シンク中<br><size=61.8033%>{item_count, plural, other {# アイテム}}</size>",
         "Indicator.Sync.UploadingVariants": "{variant_count,plural, other {# 個のアセットバリアントを}} アップロード中",
         "Indicator.Sync.SyncError": "シンクエラー! <size=50%>ログをチェックしてください</size>",
         "Indicator.Sync.StorageFull": "容量が足りません! <size=50%>シンクできません</size>",


### PR DESCRIPTION
This PR aims to enhance the appearance of the `Indicator.Sync.SyncingItems` text for the Japanese locale, aligning it more closely with the style of the English locale.

Upon investigation, I found that `Indicator.Sync.SyncingItems` is utilized in two locations: the dashboard's top indicator and the screen that waits for syncing before exiting.

The current `Indicator.Sync.SyncingItems` text in the Japanese locale is appropriate for the sync screen. However, it is too lengthy for the indicator display. Additionally, the `item_percent` variable is non-functional in the indicator.

| locale | location    |                                |
| ------ | ----------- | ------------------------------ |
| en     | indicator   | ![en-current][img-en-current]  |
| en     | sync screen | ![en-current][exit-en-current] |
| ja     | indicator   | ![ja-current][img-ja-current]  |
| ja     | sync screen | ![ja-current][exit-ja-current] |

Adjusting it to match the English locale style will make the indicator more readable.

| locale | location    |                        |
| ------ | ----------- | ---------------------- |
| ja     | indicator   | ![ja-new][img-ja-new]  |
| ja     | sync screen | ![ja-new][exit-ja-new] |

As visible in the images, some text on the sync screen has visual noise. This is a text rendering issue and not related to the translation. Although I don't consider it a significant concern, the change can be reverted if anyone finds it objectionable.

I believe, at a minimum, the indicator's appearance will improve.

[img-en-current]: https://github.com/Yellow-Dog-Man/Locale/assets/3516343/1dd363cc-7758-413d-8a75-3909428cc782
[img-ja-current]: https://github.com/Yellow-Dog-Man/Locale/assets/3516343/02ff7fc0-2b15-4033-b419-9aa6c2eca740
[img-ja-new]: https://github.com/Yellow-Dog-Man/Locale/assets/3516343/aef34dba-5c85-416a-a828-f4e0243a0578
[exit-en-current]: https://github.com/Yellow-Dog-Man/Locale/assets/3516343/4649124b-b31e-48d6-8d35-1cc080c9a175
[exit-ja-current]: https://github.com/Yellow-Dog-Man/Locale/assets/3516343/f04b941c-f871-4d28-aff7-15e3910d0e5f
[exit-ja-new]: https://github.com/Yellow-Dog-Man/Locale/assets/3516343/171d60f5-6834-425d-81ab-afc044fbedec