### PR TITLE
fix(all): remove unused locale strings

### DIFF
--- a/eo.json
+++ b/eo.json
@@ -376,7 +376,6 @@
         "Indicator.Sync.SyncingItems": "Sinkronigante {item_count,plural, one {# ero} other {# erojn}} <nobr>({item_percent} %)",
         "Indicator.Sync.UploadingVariants": "Alŝutado de {variant_count,plural, one {# asset variant} other {# asset variants}}",
         "Indicator.Sync.SyncError": "Eraro de sinkronigo! <size=50%>Check log for details</size>",
-        "Indicator.Sync.OutOfSpace": "Ekstere de spaco! <size=50%>Cannot sync</size>",
 
         "Indicator.LiveHiddenMessage": "(informoj kaŝitaj dum dissendado)",
 
@@ -400,7 +399,6 @@
         "Account.RecoverPassword": "Ĉu pasvorto perdita?",
         "Account.LiveEmailWarning": "<color = # f00> AVERTO: </color> live.com, hotmail.com, outlook.com kaj aliaj Microsoft-gastigitaj servoj povas daŭri ĝis 1-2 tagojn por akcepti la retpoŝton.",
         "Account.PasswordRules": "(almenaŭ 8 signoj, 1 cifero, 1 minuskla, 1 majuskla)",
-        "Account.AgeConfirm": "Mi aĝas 16 jarojn aŭ pli",
         "Account.LostPassword": "Perdita Pasvorto",
         "Account.SendRecoveryCode": "Sendi Rekuperan Kodon",
         "Account.ResetPasswordHeader": "Restarigi Vian Pasvorton",
@@ -500,8 +498,6 @@
         "Notifications.ReceivedContactRequest": "Sendis kontaktopeton",
         "Notifications.ReceivedInvite": "Invitas vin al:",
         "Notifications.ReceivedItem": "Sendis al vi eron:",
-        "Notifications.ReceivedTip": "Ricevita konsileto {amount} {token}",
-        "Notifications.SentTip": "Sendita konsileto {amount} {token}",
         "Notifications.VoiceMessage": "Sendis voĉan mesaĝon",
 
         "Undo.SetField": "Agordi kampon {field_name} al {value}",
@@ -1333,9 +1329,6 @@
         "Desktop.LegacyInputMode.Off": "Enigo de malnovaj funkcioj : For",
         "Desktop.Brightness": "Brilo: {n,number,percent}",
         "Desktop.Opacity": "Maldiafaneco: {n,number,percent}",
-
-        "Tutorial.Welcome.WelcomeTo": "Bonvenon al",
-        "Tutorial.Welcome.LetsStart": "Ni Komencu!",
 
         "Tutorial.Welcome.AccountHeader": "{appName}-konto",
         "Tutorial.Welcome.AccountDescription": "Krei konton donas al vi 1GB senpagan stokadon kaj aliron al konservado de artikoloj, favoraj avataroj, aldono de kontaktoj kaj mesaĝoj.",

--- a/et.json
+++ b/et.json
@@ -296,13 +296,11 @@
         "Options.Nameplates.Hide": "Nimesilt: Peida kõigil",
 
         "Indicator.OnlineUsers": "Ühendatud kasutajad: ~{num_total} ({num_registered})",
-        "Indicator.ServerStatus": "<color=#fff>Serveristaatus:</color> {status, select, Good {Hea} Slow {Halb} Down {Maas} NoInternet {Pole ühendust}} ({response_ms} ms)",
 
         "Indicator.Sync.AllSynced": "Failid Laetud",
         "Indicator.Sync.SyncingItems": "Sünkimas {item_count,plural, one {# asja} other {# asju}} <nobr>({item_percent} %)",
         "Indicator.Sync.UploadingVariants": "Laen üles {variant_count,plural, one {# asset variant} other {# asset variants}}",
         "Indicator.Sync.SyncError": "Sünkiviga! <size=50%>Vaata logi rohkema info jaoks</size>",
-        "Indicator.Sync.OutOfSpace": "Ruumi pole! <size=50%>Ei saa sünkida</size>",
 
         "Indicator.LiveHiddenMessage": "(Infot ei näidata kui olete laivis)",
 
@@ -326,7 +324,6 @@
         "Account.RecoverPassword": "Unustasite salasõna?",
         "Account.LiveEmailWarning": "<color=#f00>HOIATUS:</color> live.com, hotmail.com, outlook.com ja teised Microsofti-teenused võivad võtta 1-2 päeva emaili saatmiseks.",
         "Account.PasswordRules": "(vähemalt 8 tähemärki, 1 number, 1 väike täht, 1 suur täht)",
-        "Account.AgeConfirm": "Ma olen vähemalt 13-aastane",
         "Account.LostPassword": "Unustasin salasõna",
         "Account.SendRecoveryCode": "Saada taastamiskood",
         "Account.ResetPasswordHeader": "Lähtesta salasõna",
@@ -399,8 +396,6 @@
         "Notifications.ReceivedContactRequest": "Saatis kontaktikutse",
         "Notifications.ReceivedInvite": "Kutsub sind siia:",
         "Notifications.ReceivedItem": "Saatis sulle eseme:",
-        "Notifications.ReceivedTip": "Said tippi {amount} {token}",
-        "Notifications.SentTip": "Saatsid tippi {amount} {token}",
         "Notifications.VoiceMessage": "Häälsõnum saadetud",
 
         "Undo.SetField": "Säti väli {field_name} väärtus {value}",
@@ -1041,9 +1036,6 @@
         "Desktop.LegacyInputMode.Off": "'Legacy' sisend: Väljas",
         "Desktop.Brightness": "Heledus: {n,number,percent}",
         "Desktop.Opacity": "Läbipaistvus: {n,number,percent}",
-
-        "Tutorial.Welcome.WelcomeTo": "Tere tulemast metaversumisse",
-        "Tutorial.Welcome.LetsStart": "Alustame!",
 
         "Tutorial.Welcome.AccountHeader": "{appName} konto",
         "Tutorial.Welcome.AccountDescription": "Konto loomine annab sulle 1 GB tasuta andmeruumi ja võimaluse salvestada virtuaalseid esemeid, valida endale lemmik-avatare, lisada kontakte ja vahendada sõnumeid.",

--- a/fr.json
+++ b/fr.json
@@ -309,13 +309,11 @@
         "Options.Nameplates.Hide": "Noms: Cacher",
 
         "Indicator.OnlineUsers": "Utilisateurs en ligne: ~{num_total} ({num_registered})",
-        "Indicator.ServerStatus": "<color=#fff>Statut du serveur :</color> {status, select, Good {Bon} Slow {Lent} Down {Inaccessible} NoInternet {Sans Internet}} ({response_ms} ms)",
 
         "Indicator.Sync.AllSynced": "Synchronization complèté",
         "Indicator.Sync.SyncingItems": "Synchronization: {item_count,plural, one {# élément} other {# éléments}} <nobr>({item_percent} %)",
         "Indicator.Sync.UploadingVariants": "Chargement {variant_count,plural, one {# asset variant} other {# asset variants}}",
         "Indicator.Sync.SyncError": "Erreur de synchronisation! <size=50%>Valider les logs pour les détails</size>",
-        "Indicator.Sync.OutOfSpace": "Manque d'espace! <size=50%>Impossible de synchroniser</size>",
 
         "Indicator.LiveHiddenMessage": "(Vos informations sont cachées pendant que vous diffuser)",
 
@@ -339,7 +337,6 @@
         "Account.RecoverPassword": "Mot de passe perdu ?",
         "Account.LiveEmailWarning": "<color=#f00>ATTENTION :</color> les domaines suivants peuvent prendre jusqu'à deux jours avant d'afficher le courriel d'enregistrement: live.com, hotmail.com, outlook.com, et quelques autres services hébergés par Microsoft.",
         "Account.PasswordRules": "(au moin 8 caractères, un numéro, une majuscule, et une minuscule)",
-        "Account.AgeConfirm": "J'ai 13 ans ou plus",
         "Account.LostPassword": "Mot de passe perdu",
         "Account.SendRecoveryCode": "Envoyer le code de confirmation",
         "Account.ResetPasswordHeader": "Réinitialization du mot de passe",
@@ -439,8 +436,6 @@
         "Notifications.ReceivedContactRequest": "à envoyé une demande d'ami",
         "Notifications.ReceivedInvite": "Vous invite à:",
         "Notifications.ReceivedItem": "Vous envoie un objet:",
-        "Notifications.ReceivedTip": "Pourboire reçu: {amount} {token}",
-        "Notifications.SentTip": "Pourboire envoyé: {amount} {token}",
         "Notifications.VoiceMessage": "Envoyer un message vocal",
 
         "Undo.SetField": "Remettre {field_name} à {value}",
@@ -1265,9 +1260,6 @@
         "Desktop.LegacyInputMode.Off": "Ancien mode d'entrée : Inactif",
         "Desktop.Brightness": "Luminosité : {n,number,percent}",
         "Desktop.Opacity": "Opacité : {n,number,percent}",
-
-        "Tutorial.Welcome.WelcomeTo": "Bienvenue à",
-        "Tutorial.Welcome.LetsStart": "C'est parti!",
 
         "Tutorial.Welcome.AccountHeader": "Compte {appName}",
         "Tutorial.Welcome.AccountDescription": "La création d'un compte vous donne 1 Go de stockage gratuit et l'accès aux éléments de sauvegarde, aux avatars favoris, à l'ajout de contacts et de messagerie.",

--- a/is.json
+++ b/is.json
@@ -296,13 +296,11 @@
         "Options.Nameplates.Hide": "Nafnspjöld: Fela",
 
         "Indicator.OnlineUsers": "Virkir notendur: ~{num_registered} ({num_total})",
-        "Indicator.ServerStatus": "<color=#fff>Netþjónusta:</color> {status, select, Good {Góð} Slow {Hæg} Down {Niðri} NoInternet {Ekkert netsamband}} ({response_ms} ms)",
 
         "Indicator.Sync.AllSynced": "Allt samstillt",
         "Indicator.Sync.SyncingItems": "Samstilla {item_count,plural, one {# hlut} other {# hlutir}} <nobr>({item_percent} %)",
         "Indicator.Sync.UploadingVariants": "Upphlaða {variant_count,plural, one {# eignarafbrigði} other {# eignarafbrögð}}",
         "Indicator.Sync.SyncError": "Samstillingarvilla! <size=50%>Kíktu á log skrá fyrir gríðalega góðar upplysýngar</size>",
-        "Indicator.Sync.OutOfSpace": "Ekkert pláss til! <size=50%>Ekki hægt að framkvæma samstillingu</size>",
 
         "Indicator.LiveHiddenMessage": "(Upplysingar faldar á meðan þú ert í beinni)",
 
@@ -326,7 +324,6 @@
         "Account.RecoverPassword": "Týnt lykilorð?",
         "Account.LiveEmailWarning": "<color=#f00>VARÚÐ:</color> live.com, hotmail.com, outlook.com og aðrar Microsoft-hýsað þjónustur geta tekið up að 1-2 dagar til að samþykkja tölvupóstinn.",
         "Account.PasswordRules": "(að minnsta kosti 8 stafi, 1 tölu, 1 lítin staf og 1 stóran staf)",
-        "Account.AgeConfirm": "Ég er þrettán ára eða eldri",
         "Account.LostPassword": "Týnt lykilorð",
         "Account.SendRecoveryCode": "Senda auðkenniskóða",
         "Account.ResetPasswordHeader": "Endursetja lykilorð",
@@ -397,8 +394,6 @@
         "Notifications.ReceivedContactRequest": "Senti tengiliðabeiðni",
         "Notifications.ReceivedInvite": "Er að bjóða þig að taka þátt í:",
         "Notifications.ReceivedItem": "Senti þér hlut:",
-        "Notifications.ReceivedTip": "Fékkst klink {amount} {token}",
-        "Notifications.SentTip": "Senti klink {amount} {token}",
         "Notifications.VoiceMessage": "Senti talskilaboð",
 
         "Undo.SetField": "Filla Field {field_name} sem {value}",
@@ -570,9 +565,6 @@
         "Inspector.Mesh.SubmeshCount": "Submesh fjölda: {n}",
         "Inspector.Mesh.BoneCount": "Bein fjölda: {n}",
         "Inspector.Mesh.BlendshapeCount": "Blendshape fjölda: {n}",
-
-        "Tutorial.Welcome.WelcomeTo": "Velkomin/nn í",
-        "Tutorial.Welcome.LetsStart": "Byrjum!",
 
         "Tutorial.Welcome.AccountHeader": "{appName} reikningur",
         "Tutorial.Welcome.AccountDescription": "Að nota {appName} reikning gefur þér aðgang að 1GB ókeypis geymsluplássi. Þú getur vistað hluti og avatars, bætt fólki við sem tengilið og send skilaboð.",

--- a/nl.json
+++ b/nl.json
@@ -323,13 +323,11 @@
         "Options.Nameplates.Hide": "Naamplaten: Verborgen",
 
         "Indicator.OnlineUsers": "Online Gebruikers: {num_registered} (~{num_total})",
-        "Indicator.ServerStatus": "<color=#fff>Server Status:</color> {status, select, Good {Goed} Slow {Traag} Down {Down} NoInternet {Geen Internet}} ({response_ms} ms)",
 
         "Indicator.Sync.AllSynced": "Alles gesynchroniseerd",
         "Indicator.Sync.SyncingItems": "Synchroniseren {item_count,plural, one {# item} other {# items}} <nobr>({item_percent} %)",
         "Indicator.Sync.UploadingVariants": "Uploaden {variant_count,plural, one {# asset variant} other {# asset variants}}",
         "Indicator.Sync.SyncError": "Synchronisatiefout! <size=50%>Bekijk de log voor details</size>",
-        "Indicator.Sync.OutOfSpace": "Geen Ruimte Meer! <size=50%>Kan niet synchroniseren</size>",
 
         "Indicator.LiveHiddenMessage": "(informatie verborgen terwijl je Live bent)",
 
@@ -353,7 +351,6 @@
         "Account.RecoverPassword": "Wachtwoord Vergeten?",
         "Account.LiveEmailWarning": "<color=#f00>WAARSCHUWING:</color> Bij live.com, hotmail.com, outlook.com en andere door Microsoft gehoste services kan dit 1-2 dagen duren om de e-mail te accepteren.",
         "Account.PasswordRules": "(minimaal 8 tekens, 1 cijfer, 1 kleine letter, 1 hoofdletter)",
-        "Account.AgeConfirm": "Ik ben 13 jaar of ouder",
         "Account.LostPassword": "Wachtwoord Vergeten",
         "Account.SendRecoveryCode": "Verzend herstelcode",
         "Account.ResetPasswordHeader": "Stel je wachtwoord opnieuw in",
@@ -453,8 +450,6 @@
         "Notifications.ReceivedContactRequest": "ContactVerzoek Gekregen",
         "Notifications.ReceivedInvite": "Nodigt je uit in:",
         "Notifications.ReceivedItem": "Heeft je een item gestuurd:",
-        "Notifications.ReceivedTip": "Fooi Ontvangen {amount} {token}",
-        "Notifications.SentTip": "Verzonden Fooi {amount} {token}",
         "Notifications.VoiceMessage": "Stembericht Verstuurd",
 
         "Undo.SetField": "Veld instellen {field_name} naar {value}",
@@ -1267,9 +1262,6 @@
         "Desktop.LegacyInputMode.Off": "Legacy-invoer: Uit",
         "Desktop.Brightness": "Helderheid: {n,number,percent}",
         "Desktop.Opacity": "Ondoorzichtigheid: {n,number,percent}",
-
-        "Tutorial.Welcome.WelcomeTo": "Welkom Bij",
-        "Tutorial.Welcome.LetsStart": "Laten We Beginnen!",
 
         "Tutorial.Welcome.AccountDescription": "Creëren van een account geeft je 1 GB gratis opslag en geeft je toegang om objecten te kunnen opslaan in je inventaris, Avatars te kunnen favoriteren, Contacten te kunnen toevoegen en berichten kunnen sturen.",
         "Tutorial.Welcome.AccountCreate": "Creëer Account",

--- a/no.json
+++ b/no.json
@@ -256,13 +256,11 @@
         "Options.SeatedMode.Off": "Sittende modus: Av",
 
         "Indicator.OnlineUsers": "Online brukere: ~{num_total} ({num_registered})",
-        "Indicator.ServerStatus": "<color=#fff>Serverstatus:</color> {status, select, Good {Good} Slow {Slow} Down {Down} NoInternet {No Internet}} ({response_ms} ms)",
 
         "Indicator.Sync.AllSynced": "Allet synkronisert",
         "Indicator.Sync.SyncingItems": "Synkronisering {item_count,plural, one {# item} other {# items}} <nobr>({item_percent} %)",
         "Indicator.Sync.UploadingVariants": "Laster opp {variant_count,plural, one {# asset variant} other {# asset variants}}",
         "Indicator.Sync.SyncError": "Synkroniseringsfeil! <size=50%>Sjekk loggen for detaljer</size>",
-        "Indicator.Sync.OutOfSpace": "Tom for rom! <size=50%>Kan ikke synkronisere</size>",
 
         "Indicator.LiveHiddenMessage": "(informasjon skjult mens du er live)",
 
@@ -286,7 +284,6 @@
         "Account.RecoverPassword": "Mistet Passord?",
         "Account.LiveEmailWarning": "<color=#f00>WARNING:</color> live.com, hotmail.com, outlook.com og andre Microsoft-eide tjenester kan ta opptil 1-2 dager å godta e-posten.",
         "Account.PasswordRules": "(minst 8 tegn, 1 siffer, 1 liten bokstav, 1 stor bokstav)",
-        "Account.AgeConfirm": "Jeg er 13 år eller eldre",
         "Account.LostPassword": "Mistet Passord",
         "Account.SendRecoveryCode": "Send gjenopprettingskode",
         "Account.ResetPasswordHeader": "Tilbakestill passordet ditt",
@@ -349,8 +346,6 @@
         "Notifications.ReceivedContactRequest": "Sendte en kontaktforespørsel",
         "Notifications.ReceivedInvite": "Inviterer deg til:",
         "Notifications.ReceivedItem": "Sendte deg et element:",
-        "Notifications.ReceivedTip": "Mottatt tipp {amount} {token}",
-        "Notifications.SentTip": "Sendt tipp {amount} {token}",
 
         "Undo.SetField": "Sett felt {field_name} til {value}",
         "Undo.SetReference": "Angi referanse {ref_name} til {ref_target}",

--- a/pt-br.json
+++ b/pt-br.json
@@ -447,7 +447,6 @@
         "Account.RecoverPassword": "Esqueceu a senha?",
         "Account.LiveEmailWarning": "<color=#f00>AVISO:</color> live.com, hotmail.com, outlook.com e outros serviços hospedados pela Microsoft pode levar até 1-2 dias para aceitar o email.",
         "Account.PasswordRules": "(no mínimo 8 caracteres, 1 dígito, 1 letra em minúsculo e 1 letra em maiúsculo)",
-        "Account.AgeConfirm": "Eu tenho 13 anos de idade ou mais",
         "Account.LostPassword": "Senha Perdida",
         "Account.SendRecoveryCode": "Mandar código de recuperação",
         "Account.ResetPasswordHeader": "Redefinir sua Senha",

--- a/sv.json
+++ b/sv.json
@@ -281,13 +281,11 @@
         "Options.SeatedMode.Off": "Sittande Läge: Av",
 
         "Indicator.OnlineUsers": "Användare Online: ~{num_total} ({num_registered})",
-        "Indicator.ServerStatus": "<color=#fff>Server Status:</color> {status, select, Good {Good} Slow {Slow} Down {Down} NoInternet {No Internet}} ({response_ms} ms)",
 
         "Indicator.Sync.AllSynced": "Allt Synkat",
         "Indicator.Sync.SyncingItems": "Synkar {item_count,plural, one {# item} other {# items}} <nobr>({item_percent} %)",
         "Indicator.Sync.UploadingVariants": "Laddar Upp {variant_count,plural, one {# asset variant} other {# asset variants}}",
         "Indicator.Sync.SyncError": "Synk Error! <size=50%>Kolla i loggen för detaljer</size>",
-        "Indicator.Sync.OutOfSpace": "Slut på Minne! <size=50%>Kan inte synka</size>",
 
         "Indicator.LiveHiddenMessage": "(information är gömd medans du direktsänder)",
 

--- a/tr.json
+++ b/tr.json
@@ -270,13 +270,11 @@
         "Options.SeatedMode.Off": "Oturma Modu: Kapalı",
 
         "Indicator.OnlineUsers": "Çevrimiçi Kullanıcılar: ~{num_total} ({num_registered})",
-        "Indicator.ServerStatus": "<color=#fff>Sunucu Durumu:</color> {status, select, Good {İyi} Slow {Yavaş} Down {Çalışmıyor} NoInternet {İnternet Yok}} ({response_ms} ms)",
 
         "Indicator.Sync.AllSynced": "Tümü Senkronize Edildi",
         "Indicator.Sync.SyncingItems": "{item_count,plural, one {# item} other {# items}} <nobr>({item_percent} %) senkronize ediliyor",
         "Indicator.Sync.UploadingVariants": "{variant_count,plural, one {# asset variant} other {# asset variants} yükleniyor",
         "Indicator.Sync.SyncError": "Senkronizasyon Hatası!<size=50%>Ayrıntılar için günlüğü kontrol edin</size>",
-        "Indicator.Sync.OutOfSpace": "Alan Yetersiz! <size=50%>Senkronize edilemiyor</size>",
 
         "Indicator.LiveHiddenMessage": "(Canlıyken Bilgiler gizli)",
 
@@ -300,7 +298,6 @@
         "Account.RecoverPassword": "Şifrenizi mi kaybettiniz?",
         "Account.LiveEmailWarning": "<color=#f00>UYARI:</color> live.com, hotmail.com, outlook.com ve diğer Microsoft tarafından barındırılan hizmetlerin e-postayı kabul etmesi 1-2 gün kadar sürebilir.",
         "Account.PasswordRules": "(en az 8 karakter, 1 rakam, 1 küçük harf, 1 büyük harf)",
-        "Account.AgeConfirm": "13 yaşında veya daha büyüğüm",
         "Account.LostPassword": "Kayıp Parola",
         "Account.SendRecoveryCode": "Kurtarma Kodunu Gönder",
         "Account.ResetPasswordHeader": "Şifrenizi Sıfırlayın",
@@ -368,8 +365,6 @@
         "Notifications.ReceivedContactRequest": "Bir iletişim isteği gönderildi",
         "Notifications.ReceivedInvite": "Sizi davet ediyor:",
         "Notifications.ReceivedItem": "Size bir öğe gönderdi:",
-        "Notifications.ReceivedTip": "Alınan ipucu {amount} {token}",
-        "Notifications.SentTip": "Gönderilen ipucu {amount} {token}",
         "Notifications.VoiceMessage": "Sesli mesaj gönderdi",
 
         "Undo.SetField": "{field_name} alanını {value} olarak ayarlayın",
@@ -1037,9 +1032,6 @@
         "Wizard.AssetOptimization.RecalculateAllNormalsMerged": "Tüm Normalleri Yeniden Hesapla (birleştirilmiş)",
         "Wizard.AssetOptimization.RecalculateAllTangents": "Tüm Teğetleri Yeniden Hesapla (Mikktspace)",
         "Wizard.AssetOptimization.ResizedResult": "Yeniden boyutlandır {n}",
-
-        "Tutorial.Welcome.WelcomeTo": "Hoşgeldiniz",
-        "Tutorial.Welcome.LetsStart": "Başlayalım!",
 
         "Tutorial.Welcome.AccountHeader": "{appName} hesabı",
         "Tutorial.Welcome.AccountDescription": "Hesap oluşturma, 1 GB ücretsiz depolama alanı ve öğeleri kaydetme, avatarları kaydetme, kişi ekleme ve mesajlaşma olanağı sağlar.",


### PR DESCRIPTION
I'm working on some tooling to spot these in our PRs, so more don't get left behind. In developing this tooling I found that these strings are not used but present in other locale files.

See: https://github.com/Yellow-Dog-Man/InternalDiscussion/issues/198#issuecomment-1719127098 for more information