### PR TITLE
ja: Adjustment of RichPresence-related wording

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -2073,10 +2073,10 @@
         "Tools.Names.Label": "Label ツール",
 
         "Discord.RichPresence.InPrivateWorld": "プライベートワールドにいます",
-        "Discord.RichPresence.InPrivateLargeText": "プライベートワールド({version})",
+        "Discord.RichPresence.InPrivateLargeText": "プライベートワールド ({version})",
         "Discord.RichPresence.InPublicWorld": "パブリックワールドにいます",
         "Discord.RichPresence.PublicWorldDetails": "{worldName} ({totalWorlds}ワールド)",
-        "Discord.RichPresence.InPublicLargeText": "パブリックワールド({version})",
+        "Discord.RichPresence.InPublicLargeText": "パブリックワールド ({version})",
 
         "Dummy": "Dummy"
     }

--- a/ja.json
+++ b/ja.json
@@ -2072,9 +2072,9 @@
         "Tools.Names.Measure": "Measure ツール",
         "Tools.Names.Label": "Label ツール",
 
-        "Discord.RichPresence.InPrivateWorld": "プライベートワールドにいます",
+        "Discord.RichPresence.InPrivateWorld": "プライベートワールド",
         "Discord.RichPresence.InPrivateLargeText": "プライベートワールド ({version})",
-        "Discord.RichPresence.InPublicWorld": "パブリックワールドにいます",
+        "Discord.RichPresence.InPublicWorld": "パブリックワールド",
         "Discord.RichPresence.PublicWorldDetails": "{worldName} ({totalWorlds}ワールド)",
         "Discord.RichPresence.InPublicLargeText": "パブリックワールド ({version})",
 


### PR DESCRIPTION
This PR contains two changes:

It's a small change, but I think it's a necessary change.

## Add space before version text in LargetText

<table>
<tr>
<td>
old
</td>
<td>

![image](https://github.com/Yellow-Dog-Man/Locale/assets/3516343/ae00d053-1016-4b34-b3a9-f3d4eb42127a)

</td>
<tr>
<td>
new
</td>
<td>

![image](https://github.com/Yellow-Dog-Man/Locale/assets/3516343/8a92bdd9-a4cb-4b73-883d-b36f78469cc2)

</td>
</table>

## Adjusted RichPresence status text to be more concise

The current character count is a bit long and extends beyond Discord's display area. There is a text at the back that shows the number of people in the instance, but you always have to hover over it to see it.
In fact, I just deleted the word for "In" in English.

<table>
<tr>
<td>
old
</td>
<td>

![2023-11-17_21-11-39_Discord](https://github.com/Yellow-Dog-Man/Locale/assets/3516343/96f2a080-b918-4739-9490-c5383ccf33e5)

</td>
<tr>
<td>
new
</td>
<td>

![2023-11-17_21-10-56_chrome](https://github.com/Yellow-Dog-Man/Locale/assets/3516343/b33d388a-282c-41a7-9933-2d7490cf1971)

</td>
</table>

