### PR TITLE
fix: login expire limit

### DIFF
--- a/eo.json
+++ b/eo.json
@@ -508,7 +508,7 @@
         "Account.Anonymous": "Anonima",
         "Account.Username": "Uzantnomo:",
         "Account.Email": "Retpoŝto:",
-        "Account.RememberMe": "Memoru Min (dum 7 tagoj):",
+        "Account.RememberMe": "Memoru Min (dum 30 tagoj):",
         "Account.RepeatEmail": "Ripeti Retpoŝton:",
         "Account.UsernameOrEmail": "Uzantnomo aŭ Retpoŝto:",
         "Account.Password": "Pasvorto:",

--- a/nl.json
+++ b/nl.json
@@ -343,7 +343,7 @@
         "Account.Anonymous": "Anoniem",
         "Account.Username": "Gebruikersnaam:",
         "Account.Email": "E-mail:",
-        "Account.RememberMe": "Onthoud mij (voor 7 dagen):",
+        "Account.RememberMe": "Onthoud mij (voor 30 dagen):",
         "Account.RepeatEmail": "Herhaal email:",
         "Account.UsernameOrEmail": "Gebruikersnaam of email:",
         "Account.Password": "Wachtwoord:",

--- a/pl.json
+++ b/pl.json
@@ -509,7 +509,7 @@
         "Account.Anonymous": "Anonim",
         "Account.Username": "Nazwa Użytkownika:",
         "Account.Email": "Email:",
-        "Account.RememberMe": "Zapamiętaj Mnie (na 7 dni):",
+        "Account.RememberMe": "Zapamiętaj Mnie (na 30 dni):",
         "Account.RepeatEmail": "Powtórz email:",
         "Account.UsernameOrEmail": "Nazwa Użytkownika lub Email:",
         "Account.Password": "Hasło:",


### PR DESCRIPTION
Fixed an issue where the number of days in RememberMe for login was incorrect in multiple languages.