### PR TITLE
Small fixes for de.json

### DIFF
--- a/de.json
+++ b/de.json
@@ -839,7 +839,7 @@
         "CreateNew.Text.Outline": "Kontur",
 
         "CreateNew.Editor": "Assistenten",
-        "CreateNew.Editor.UserInspector": "Benutzer-Assistent",
+        "CreateNew.Editor.UserInspector": "Benutzerinspektor",
         "CreateNew.Editor.LightSourcesWizard": "Welt-Lichtquellen-Assistent",
         "CreateNew.Editor.TextRendererWizard": "Welt-Textrenderer-Assistent",
         "CreateNew.Editor.AssetOptimizationWizard": "Asset-Optimierungs-Assistent",
@@ -976,7 +976,7 @@
         "Importer.Model.Advanced.FlatShaded": "Flach schattieren",
         "Importer.Model.Advanced.DeduplicateInstances": "Instanzen-Duplikate entfernen (langsam)",
         "Importer.Model.Advanced.Optimize": "Modell/Szene optimieren",
-        "Importer.Model.Advanced.SplitSubmeshes": "Unter-Mesh spalten",
+        "Importer.Model.Advanced.SplitSubmeshes": "Submeshes spalten",
         "Importer.Model.Advanced.RandomColors": "Zufällige Farben generieren",
         "Importer.Model.Advanced.SpawnMaterialOrbs": "Material-Orbs spawnen",
         "Importer.Model.Advanced.ImagesByName": "Bilder per Name importieren",


### PR DESCRIPTION
Fixes:
- A single instance of submeshes was translated as "Unter-Mesh" as opposed to "Submeshes" in German.
- The user inspector was translated as "Benutzer-Assistent" in one place instead of "Benutzerinspektor", using the name for the wizards instead of inspectors.