### PR TITLE
all languages: fixed UI.VideoPlayer.BroadcastAudio key

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -1959,7 +1959,7 @@
         "UI.VideoPlayer.LocalSettings": "Lokální<br>nastavení",
         "UI.VideoPlayer.SpatialAudio": "Prostorové<br>audio",
         "UI.VideoPlayer.AreaBroadcast": "Oblastní<br>vysílání",
-        "UI.VideoPlayer.BroascastAudio": "Vysílané<br>audio",
+        "UI.VideoPlayer.BroadcastAudio": "Vysílané<br>audio",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Zadejte URL zde</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Lokální <br>v kině",
         "UI.VideoPlayer.AudioZoneGlobal": "Slyšitelné<br>ve Světě",

--- a/de.json
+++ b/de.json
@@ -2030,7 +2030,7 @@
         "UI.VideoPlayer.LocalSettings": "Lokale<br>Optionen",
         "UI.VideoPlayer.SpatialAudio": "<nobr>Räumliches</nobr><br>Audio",
         "UI.VideoPlayer.AreaBroadcast": "<nobr>Umgebungs</nobr><br>Broadcast",
-        "UI.VideoPlayer.BroascastAudio": "Broadcast<br>Audio",
+        "UI.VideoPlayer.BroadcastAudio": "Broadcast<br>Audio",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>URL hier eingeben</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Im Theater<br>hörbar",
         "UI.VideoPlayer.AudioZoneGlobal": "Sitzungsweit<br>hörbar",

--- a/en.json
+++ b/en.json
@@ -2038,7 +2038,7 @@
         "UI.VideoPlayer.LocalSettings": "Local<br>Settings",
         "UI.VideoPlayer.SpatialAudio": "Spatialized<br>Audio",
         "UI.VideoPlayer.AreaBroadcast": "Area<br>Broadcast",
-        "UI.VideoPlayer.BroascastAudio": "Broadcast<br>Audio",
+        "UI.VideoPlayer.BroadcastAudio": "Broadcast<br>Audio",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Enter URL Here</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Local to<br>Theater",
         "UI.VideoPlayer.AudioZoneGlobal": "Audible<br>to World",

--- a/eo.json
+++ b/eo.json
@@ -2001,7 +2001,7 @@
         "UI.VideoPlayer.LocalSettings": "Loka<br>Agordoj",
         "UI.VideoPlayer.SpatialAudio": "Spaca<br>Aŭdio",
         "UI.VideoPlayer.AreaBroadcast": "Zona<br>Elsendo",
-        "UI.VideoPlayer.BroascastAudio": "Ellsendata<br>Sono",
+        "UI.VideoPlayer.BroadcastAudio": "Ellsendata<br>Sono",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Eniru URL-on Ĉi tien</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Loke al<br>Teatro",
         "UI.VideoPlayer.AudioZoneGlobal": "Aŭdebla<br>al Mondo",

--- a/es.json
+++ b/es.json
@@ -1906,7 +1906,7 @@
         "UI.VideoPlayer.LocalSettings": "Opciones<br>Locales",
         "UI.VideoPlayer.SpatialAudio": "Audio<br>Espacializado",
         "UI.VideoPlayer.AreaBroadcast": "Emisión<br>en Área",
-        "UI.VideoPlayer.BroascastAudio": "Emitir<br>Audio",
+        "UI.VideoPlayer.BroadcastAudio": "Emitir<br>Audio",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Ingrese URL aquí</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Local al<br>Teatro",
         "UI.VideoPlayer.AudioZoneGlobal": "Audible<br>al Mundo",

--- a/fr.json
+++ b/fr.json
@@ -2030,7 +2030,7 @@
         "UI.VideoPlayer.LocalSettings": "Option<br>Locales",
         "UI.VideoPlayer.SpatialAudio": "Audio<br>Spatial",
         "UI.VideoPlayer.AreaBroadcast": "Diffusion<br>de zone",
-        "UI.VideoPlayer.BroascastAudio": "Diffusion<br>globale",
+        "UI.VideoPlayer.BroadcastAudio": "Diffusion<br>globale",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Entrez une URL ici</alpha></i>",
         "UI.VideoPlayer.AudioZoneTheater": "Local vers<br>home cinéma",
         "UI.VideoPlayer.AudioZoneGlobal": "Audible<br>dans le monde",

--- a/ja.json
+++ b/ja.json
@@ -2030,7 +2030,7 @@
         "UI.VideoPlayer.LocalSettings": "ローカル<br>音量設定",
         "UI.VideoPlayer.SpatialAudio": "空間<br>音響",
         "UI.VideoPlayer.AreaBroadcast": "エリア<br>ブロードキャスト",
-        "UI.VideoPlayer.BroascastAudio": "2D<br>音響",
+        "UI.VideoPlayer.BroadcastAudio": "2D<br>音響",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>ここにURLを入力</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "シアター内<br>のみ",
         "UI.VideoPlayer.AudioZoneGlobal": "ワールド内<br>全体",

--- a/ko.json
+++ b/ko.json
@@ -2030,7 +2030,7 @@
         "UI.VideoPlayer.LocalSettings": "로컬",
         "UI.VideoPlayer.SpatialAudio": "구역",
         "UI.VideoPlayer.AreaBroadcast": "지역",
-        "UI.VideoPlayer.BroascastAudio": "음향송출",
+        "UI.VideoPlayer.BroadcastAudio": "음향송출",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>여기에 주소를 입력하세요</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "로컬에서<br>극장모드로",
         "UI.VideoPlayer.AudioZoneGlobal": "전역<br>송출",

--- a/no.json
+++ b/no.json
@@ -1900,7 +1900,7 @@
         "UI.VideoPlayer.LocalSettings": "Lokale<br>innstillinger",
         "UI.VideoPlayer.SpatialAudio": "Romlig<br>lyd",
         "UI.VideoPlayer.AreaBroadcast": "Område<br>sending",
-        "UI.VideoPlayer.BroascastAudio": "Sending<br>lyd",
+        "UI.VideoPlayer.BroadcastAudio": "Sending<br>lyd",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Skriv inn URL her</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Lokal til<br>teater",
         "UI.VideoPlayer.AudioZoneGlobal": "Hørbar<br>til verden",

--- a/pl.json
+++ b/pl.json
@@ -2025,7 +2025,7 @@
         "UI.VideoPlayer.LocalSettings": "Ustawienia<br>Lokalne",
         "UI.VideoPlayer.SpatialAudio": "Przestrzenny<br>Dźwięk",
         "UI.VideoPlayer.AreaBroadcast": "Obszar<br>nadawania",
-        "UI.VideoPlayer.BroascastAudio": "Nadawanie<br>Audio",
+        "UI.VideoPlayer.BroadcastAudio": "Nadawanie<br>Audio",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Wpisz tutaj adres URL</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Lokalnie do<br>Teatru",
         "UI.VideoPlayer.AudioZoneGlobal": "Słyszalne<br>dla świata",

--- a/pt-br.json
+++ b/pt-br.json
@@ -1900,7 +1900,7 @@
         "UI.VideoPlayer.LocalSettings": "Opções<br>Locais",
         "UI.VideoPlayer.SpatialAudio": "Áudio<br>Espacial",
         "UI.VideoPlayer.AreaBroadcast": "Áudio<br>Global",
-        "UI.VideoPlayer.BroascastAudio": "Áudio<br>Transmitido",
+        "UI.VideoPlayer.BroadcastAudio": "Áudio<br>Transmitido",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Digite a URL aqui</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Local para<br>o Ambiente",
         "UI.VideoPlayer.AudioZoneGlobal": "Audível<br>para o Mundo Todo",

--- a/ru.json
+++ b/ru.json
@@ -2030,7 +2030,7 @@
         "UI.VideoPlayer.LocalSettings": "Локальные<br>настройки",
         "UI.VideoPlayer.SpatialAudio": "Пространственное<br>Аудио",
         "UI.VideoPlayer.AreaBroadcast": "Вещание<br>в области",
-        "UI.VideoPlayer.BroascastAudio": "Глобальное<br>вещание",
+        "UI.VideoPlayer.BroadcastAudio": "Глобальное<br>вещание",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>Введите URL...</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "Звук:<br>Кинозал",
         "UI.VideoPlayer.AudioZoneGlobal": "Звук:<br>Глобальный",

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1905,7 +1905,7 @@
         "UI.VideoPlayer.LocalSettings": "本地<br>设置",
         "UI.VideoPlayer.SpatialAudio": "空间<br>音频",
         "UI.VideoPlayer.AreaBroadcast": "区域<br>广播",
-        "UI.VideoPlayer.BroascastAudio": "广播<br>音频",
+        "UI.VideoPlayer.BroadcastAudio": "广播<br>音频",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>在此输入URL</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "本地<br>剧院",
         "UI.VideoPlayer.AudioZoneGlobal": "世界<br>音频",

--- a/zh-tw.json
+++ b/zh-tw.json
@@ -1905,7 +1905,7 @@
         "UI.VideoPlayer.LocalSettings": "本地<br>設置",
         "UI.VideoPlayer.SpatialAudio": "空間<br>音頻",
         "UI.VideoPlayer.AreaBroadcast": "區域<br>廣播",
-        "UI.VideoPlayer.BroascastAudio": "廣播<br>音頻",
+        "UI.VideoPlayer.BroadcastAudio": "廣播<br>音頻",
         "UI.VideoPlayer.EnterURL": "<i><alpha=#77>在此輸入URL</closeall>",
         "UI.VideoPlayer.AudioZoneTheater": "本地<br>劇院",
         "UI.VideoPlayer.AudioZoneGlobal": "世界<br>音頻",


### PR DESCRIPTION
The string key in default video player is "UI.VideoPlayer.BroadcastAudio", changing it in the strings file for it to properly show the text.

Related to #12 

![Untitled](https://github.com/Yellow-Dog-Man/Locale/assets/11510682/fc17942e-6f58-4474-b25c-0cb3e4ff3a34)
