### PR TITLE
feat(en): add Twitch Interface Settings keys

### DIFF
--- a/en.json
+++ b/en.json
@@ -1214,6 +1214,7 @@
         "Settings.WindowsSettings": "Windows Settings",
         "Settings.DebugSettings": "Debug",
         "Settings.LegacyFeatureSettings": "Legacy Features",
+        "Settings.TwitchInterfaceSettings": "Twitch Streaming Interface",
 
         "Settings.MessagingPrivacySettings": "Messaging Privacy",
 
@@ -1398,6 +1399,9 @@
         "Settings.LegacyFeatureSettings.UseLegacyGripEquip.Description": "When enabled, you can equip tools and gadgets by pressing grip twice in rapid succession. This setting will likely get removed at some point.",
         "Settings.LegacyFeatureSettings.UseLegacyWorldSwitcher": "Use legacy world switcher",
         "Settings.LegacyFeatureSettings.UseLegacyWorldSwitcher.Description": "When enabled, the app button on your non-primary hand will open a legacy world switch to switch between active worlds. This feature will be replaced in the future by a more flexible solution.",
+
+        "Settings.TwitchInterfaceSettings.ChannelName": "Twitch Channel Name",
+        "Settings.TwitchInterfaceSettings.ChannelName.Description": "This sets the default Twitch channel name for the Twitch Chat panel in the Camera Controls panel. This is mostly used by Twitch streamers who want to see their Twitch chat.",
 
         "Settings.MessagingPrivacySettings.DoNotSendReadStatus": "Do not send realtime read status",
         "Settings.MessagingPrivacySettings.DoNotSendReadStatus.Description": "When enabled, other users won't be able to see when you have read their messages immediatelly. You will also not see when they have read yours.",


### PR DESCRIPTION
This adds `en` keys for the **Twitch Streaming Interface Settings** in the new **Settings UI**. 

Addresses #247.