### PR TITLE
feat(en): add cuteness settings key

### DIFF
--- a/en.json
+++ b/en.json
@@ -1319,6 +1319,8 @@
         "Settings.UserMetricsSettings.UserHeight": "Height",
         "Settings.UserMetricsSettings.UserHeight.Description": "This is your real world height, which is used to properly scale your avatar so it fits you well. It is also the height you will be placed at when you enable seated mode.\n\nYou can enter your height by using appropriate units, for example by typing <nobr><color=hero.yellow>175 cm</color></nobr> or <nobr><color=hero.yellow>1.75 m</color></nobr> for metric or <color=hero.yellow>5'11\"</color> for imperial.",
 
+        "Settings.CutenessSettings": "Super Turbo Ultimate Cuteness Setting",
+
         "Settings.AudioInputDeviceSettings.UseSystemDefault": "Use System Default Input Device",
         "Settings.AudioInputDeviceSettings.UseSystemDefault.Description": "Enable this to automatically use the input device you have set as default input in your system. If you'd like to override this and use a specific device instead, disable this option and configure the preferred devices below.",
         "Settings.AudioInputDeviceSettings.DevicePriorities": "Configure Default Audio Input Device",


### PR DESCRIPTION
In https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1756, I noticed that the key `Settings.CutenessSettings` is missing from the locale. I know this is a joke setting that will only be viewable by one person (unless modded), but it should have a key defined in the locale, so here you go.