### PR TITLE
Fix ja.json

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -1,6 +1,6 @@
 {
     "localeCode": "ja",
-    "authors": ["orange", "Melnus", "Aesc", "kazu", "Rabbuttz", "zozokasu", "rhenium", "chaba_take"],
+    "authors": ["orange", "Melnus", "Aesc", "kazu", "Rabbuttz", "zozokasu", "rhenium", "chaba_take", "hantabaru1014"],
     "messages": {
 
         "General.OK": "OK",
@@ -1386,8 +1386,8 @@
 
         "Settings.UserRestrictionsSettings.DebugReset": "ユーザー制限をリセット",
 
-        "Settings.WindowsSettings.KeepOriginalScreenshotFormat": "WebP形式で保存(透過を維持)",
-        "Settings.WindowsSettings.KeepOriginalScreenshotFormat.Description": "設定を有効にするとスクーンショットはWebP形式で保存され、透過情報が保持されます。設定を無効にするとJPGやPNGに変換されて保存され、画像の透過情報は保持されません。画像アプリによってはWebP形式は開けない場合があります。",
+        "Settings.WindowsSettings.KeepOriginalScreenshotFormat": "スクリーンショットを変換しない",
+        "Settings.WindowsSettings.KeepOriginalScreenshotFormat.Description": "設定を有効にするとスクリーンショットは元の形式(カメラによる設定)で保存されます。設定を無効にするとJPGに変換されて保存され、画像の透過情報は保持されません。アプリによってはWebP形式等が開けない場合があるため互換性を重視する場合には無効に設定してください。",
 
         "Settings.DebugSettings.DebugInputBindings": "インプットバインディングのデバッグ",
         "Settings.DebugSettings.DebugInputBindings.Description": "設定を有効にした場合、インプットバインディングシステムのデバッグ情報が表示されます。主に開発者向けの機能です。",


### PR DESCRIPTION
Fixed the Japanese translation of KeepOriginalScreenshotFormat because it was inaccurate to make it easier to understand