### PR TITLE
[en] Fix missing strings for selecting locale on Welcome screen

### DIFF
--- a/en.json
+++ b/en.json
@@ -1606,8 +1606,8 @@
         "Settings.LocaleSettings.AvailableLocales": "Select Locale",
         "Settings.LocaleSettings.AvailableLocales.Breadcrumb": "Locales",
 
-	    "Settings.Locale.SelectLanguageHeader": "Select Locale",
-	    "Settings.Locale.DefaultLanguage": "Default Language",
+        "Settings.Locale.SelectLanguageHeader": "Select Locale",
+        "Settings.Locale.DefaultLanguage": "Default Language",
 
         "Settings.DashSettings.DashCurvature": "Curvature",
         "Settings.DashSettings.DashCurvature.Description": "This controls how curved the dash is when you are in VR. Setting it to 0 will make it completely flat.",

--- a/en.json
+++ b/en.json
@@ -1606,8 +1606,8 @@
         "Settings.LocaleSettings.AvailableLocales": "Select Locale",
         "Settings.LocaleSettings.AvailableLocales.Breadcrumb": "Locales",
 
-	"Settings.Locale.SelectLanguageHeader": "Select Locale",
-	"Settings.Locale.DefaultLanguage": "Default Language",
+	    "Settings.Locale.SelectLanguageHeader": "Select Locale",
+	    "Settings.Locale.DefaultLanguage": "Default Language",
 
         "Settings.DashSettings.DashCurvature": "Curvature",
         "Settings.DashSettings.DashCurvature.Description": "This controls how curved the dash is when you are in VR. Setting it to 0 will make it completely flat.",

--- a/en.json
+++ b/en.json
@@ -1606,6 +1606,9 @@
         "Settings.LocaleSettings.AvailableLocales": "Select Locale",
         "Settings.LocaleSettings.AvailableLocales.Breadcrumb": "Locales",
 
+	"Settings.Locale.SelectLanguageHeader": "Select Locale",
+	"Settings.Locale.DefaultLanguage": "Default Language",
+
         "Settings.DashSettings.DashCurvature": "Curvature",
         "Settings.DashSettings.DashCurvature.Description": "This controls how curved the dash is when you are in VR. Setting it to 0 will make it completely flat.",
         "Settings.DashSettings.OpenCloseSpeed": "Open/close speed",


### PR DESCRIPTION
This fixes the missing strings for selecting the locale on the Welcome screen when Resonite is first launched.

Partially fixes https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2250