### PR TITLE
fix: readd metric and imperial keys from previous legacy keys

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "Vzestupně",
         "General.Sort.Descending": "Sestupně",
 
+        "General.Units.Metric": "Metrická",
+        "General.Units.Imperial": "Imperiální",
+
         "Worlds.Home" : "Domov",
         "Worlds.Tutorial" : "Tutorial",
 

--- a/eo.json
+++ b/eo.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "Kreskante",
         "General.Sort.Descending": "Malkreskante",
 
+        "General.Units.Metric": "Metrika",
+        "General.Units.Imperial": "Imperia",
+
         "Worlds.Home" : "Hejmo",
         "Worlds.Tutorial" : "Lernilo",
 

--- a/es.json
+++ b/es.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "Ascendente",
         "General.Sort.Descending": "Descendente",
 
+        "General.Units.Metric": "Métrico",
+        "General.Units.Imperial": "Imperial",
+
         "Worlds.Home": "Hogar",
         "Worlds.Tutorial": "Tutorial",
 

--- a/et.json
+++ b/et.json
@@ -32,6 +32,9 @@
         "General.Sort.Ascending": "Tõusvas",
         "General.Sort.Descending": "Langevas",
 
+        "General.Units.Metric": "Meetersüsteemis",
+        "General.Units.Imperial": "Tollisüsteemis",
+
         "Locomotion.Noclip.Name": "Takistusteta",
         "Locomotion.Noclip.Description": "Takistusteta lendamine, sobib ehitamiseks hästi.",
         "Locomotion.Teleport.Name": "Teleporteerumine",

--- a/is.json
+++ b/is.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "Hækkandi",
         "General.Sort.Descending": "Lækkandi",
 
+        "General.Units.Metric": "Metrakerfi",
+        "General.Units.Imperial": "Tómmumál",
+
         "Worlds.Home" : "Heima",
         "Worlds.Tutorial" : "Byrjendanámskeið",
 

--- a/nl.json
+++ b/nl.json
@@ -45,6 +45,9 @@
         "General.Sort.Ascending": "Oplopend",
         "General.Sort.Descending": "Aflopend",
 
+        "General.Units.Metric": "Metrisch",
+        "General.Units.Imperial": "Imperiaal",
+
         "Locomotion.Noclip.Name": "Noclip",
         "Locomotion.Noclip.Description": "Eenvoudige vliegmodus zonder colisie, ideaal voor editing.",
         "Locomotion.Teleport.Name": "Teleporteren",

--- a/no.json
+++ b/no.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "Stigende",
         "General.Sort.Descending": "synkende",
 
+        "General.Units.Metric": "Metrisk",
+        "General.Units.Imperial": "Imperial",
+
         "Worlds.Home": "Hjemme",
         "Worlds.Tutorial": "Veiledning",
 

--- a/pl.json
+++ b/pl.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "Rosnąco",
         "General.Sort.Descending": "Malejąco",
 
+        "General.Units.Metric": "Metryczny",
+        "General.Units.Imperial": "Imperialny",
+
         "Worlds.Home": "Dom",
         "Worlds.Tutorial": "Tutorial",
 

--- a/pt-br.json
+++ b/pt-br.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "Crescente",
         "General.Sort.Descending": "Decrescente",
 
+        "General.Units.Metric": "Métrico",
+        "General.Units.Imperial": "Imperial",
+
         "Worlds.Home" : "Casa",
         "Worlds.Tutorial" : "Tutorial",
 

--- a/tr.json
+++ b/tr.json
@@ -29,6 +29,9 @@
         "General.Sort.Ascending": "Artan",
         "General.Sort.Descending": "Azalan",
 
+        "General.Units.Metric": "Metrik",
+        "General.Units.Imperial": "Imperial",
+
         "Locomotion.Noclip.Name": "Klipsiz",
         "Locomotion.Noclip.Description": "Basit, klipsiz uçuş modu, düzenleme için ideal.",
         "Locomotion.Teleport.Name": "Teleport",

--- a/zh-tw.json
+++ b/zh-tw.json
@@ -55,6 +55,9 @@
         "General.Sort.Ascending": "升序",
         "General.Sort.Descending": "降序",
 
+        "General.Units.Metric": "公制",
+        "General.Units.Imperial": "英制",
+
         "Worlds.Home" : "家",
         "Worlds.Tutorial" : "教程",
 


### PR DESCRIPTION
This PR aims to readd the missing `General.Units.Metric` and `General.Units.Imperial` keys that were not migrated over from the legacy `Settings.Metric` and `Settings.Imperial` keys in certain languages. These legacy keys were removed when the new Settings UI update was released. All values in this PR are based on 25ce3868d90dc53dd7cedf8bc16b6b2d794e6a62, which is the last commit that had these legacy keys.