### PR TITLE
Update: en-gb.json

### DIFF
--- a/en-gb.json
+++ b/en-gb.json
@@ -1,6 +1,6 @@
 {
     "localeCode": "en-gb",
-    "authors": ["Nammi", "Enverex", "atomicwave", "CyberZott"],
+    "authors": ["Nammi", "Enverex", "atomicwave", "CyberZott", "paradox19"],
     "messages": {
 
         "Undo.ChangeColor": "Change Colour",

--- a/en-gb.json
+++ b/en-gb.json
@@ -1,6 +1,6 @@
 {
     "localeCode": "en-gb",
-    "authors": ["Nammi", "Enverex", "atomicwave", "CyberZott", "paradox19"],
+    "authors": ["Nammi", "Enverex", "atomicwave", "CyberZott"],
     "messages": {
 
         "Undo.ChangeColor": "Change Colour",

--- a/en-gb.json
+++ b/en-gb.json
@@ -57,6 +57,9 @@
         "Tools.Names.Color": "Colour Tool",
         "Tools.StreamAudio.Spatialized": "Spatialised",
 
+        "Settings.AudioInputFilteringSettings.UseVoiceNormalization": "Voice normalisation",
+        "Settings.AudioInputFilteringSettings.NormalizationThreshold": "Normalisation threshold",
+
         "Dummy": "Dummy"
     }
 }


### PR DESCRIPTION
Added keys for:
- "Settings.AudioInputFilteringSettings.UseVoiceNormalization"
- "Settings.AudioInputFilteringSettings.NormalizationThreshold"

As they were using the fallback, American English, keys.
*(Also, I don't know if I should add my own name to the author's list as it's only two keys)*

discord username: `paradoxical_autumn`
resonite username: `paradox19`