### PR TITLE
fix(en): add missing inspector texture keys for alpha and alpha gamma

### DIFF
--- a/en.json
+++ b/en.json
@@ -2068,6 +2068,9 @@
         "Inspector.Texture.NormalizeMinMax": "Normalize (min and max)",
         "Inspector.Texture.NormalizeIndependent": "Normalize RGB independently (min and max)",
         "Inspector.Texture.BleedColorToAlpha": "Bleed Color To Alpha",
+        "Inspector.Texture.AlphaGamma": "Alpha Gamma",
+        "Inspector.Texture.AdjustAlphaGamma": " Adjust Alpha Gamma",
+        "Inspector.Texture.AddAlpha": "Add Alpha",
 
         "Inspector.Texture.InvalidFloats": "Diagnostic: Invalid floats",
         "Inspector.Texture.GenerateMetadata": "Diagnostic: Generate Bitmap Metadata",


### PR DESCRIPTION
Adds the followinng missing keys currently used for image manipulation for StaticTexture2D within an inspector:

- `Inspector.Texture.AlphaGamma`
- `Inspector.Texture.AdjustAlphaGamma`
- `Inspector.Texture.AddAlpha`

Resolves #400 