### PR TITLE
CleanJSON.py: add missing keys from the source file, and reformat with black

### DIFF
--- a/CleanJSON.py
+++ b/CleanJSON.py
@@ -97,6 +97,9 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    if args.lang is None or args.en is None or args.out is None:
+        parser.print_help()
+        exit(1)
     N = LocaleCleaner(args.en, args.lang, args.out, args.add_missing_keys)
     N.run()
     print("Cleaned!")

--- a/CleanJSON.py
+++ b/CleanJSON.py
@@ -20,6 +20,12 @@ class LocaleCleaner:
         self.save()
 
     def make_header(self):
+        """
+        {
+            "localeCode": "en",
+            "authors": ["author1", "author2", ],
+            "messages": {
+        """
         self.output.append("{")
         self.output.append('    "localeCode": "{}",'.format(self.lang["localeCode"]))
         self.output.append(
@@ -28,6 +34,11 @@ class LocaleCleaner:
         self.output.append('    "messages": {')
 
     def make_footer(self):
+        """
+                "Dummy": "Dummy"
+            }
+        }
+        """
         self.output.append('        "Dummy": "Dummy"')
         self.output.append("    }")
         self.output.append("}")

--- a/CleanJSON.py
+++ b/CleanJSON.py
@@ -58,7 +58,7 @@ class LocaleCleaner:
             elif self.add_missing_keys and key != "":
                 blank = False
                 value = kv[1].strip().rstrip(",")[1:-1]
-                self.output.append('        "{}": "{}",'.format(key, value))
+                self.output.append('        "#{}": "{}",'.format(key, value))
             elif blank == False:
                 self.output.append("")
                 blank = True
@@ -94,7 +94,7 @@ if __name__ == "__main__":
         "-a",
         "--add-missing-keys",
         action="store_true",
-        help="If a key is missing in the translation, copy original text from en.json to the output file.",
+        help="If a key is missing in the translation, copy original text from en.json to the output file.  The key will be prefixed with #.",
     )
 
     args = parser.parse_args()

--- a/CleanJSON.py
+++ b/CleanJSON.py
@@ -2,33 +2,36 @@
 
 import json
 
+
 class LocaleCleaner:
     def __init__(self, en, lang, out, add_missing_keys=False):
-        en_file = open(en, 'r', encoding="utf8")
-        lang_file = open(lang, 'r', encoding="utf8")
+        en_file = open(en, "r", encoding="utf8")
+        lang_file = open(lang, "r", encoding="utf8")
         self.out = out
         self.en = en_file.readlines()
         self.lang = json.load(lang_file)
         self.output = []
-        self.add_missing_keys=add_missing_keys
-        
+        self.add_missing_keys = add_missing_keys
+
     def run(self):
         self.make_header()
         self.parse()
         self.make_footer()
         self.save()
-    
+
     def make_header(self):
-        self.output.append('{')
+        self.output.append("{")
         self.output.append('    "localeCode": "{}",'.format(self.lang["localeCode"]))
-        self.output.append('    "authors": ["{}"],'.format('", "'.join(self.lang["authors"])))
+        self.output.append(
+            '    "authors": ["{}"],'.format('", "'.join(self.lang["authors"]))
+        )
         self.output.append('    "messages": {')
-        
+
     def make_footer(self):
         self.output.append('        "Dummy": "Dummy"')
-        self.output.append('    }')
-        self.output.append('}')
-        self.output.append('')
+        self.output.append("    }")
+        self.output.append("}")
+        self.output.append("")
 
     def find_start(self):
         counter = 0
@@ -37,44 +40,62 @@ class LocaleCleaner:
             if "message" in line:
                 break
         return counter
-        
+
     def parse(self):
         start_pos = self.find_start()
         blank = False
         for line in self.en[start_pos:]:
             if '"Dummy": "Dummy"' in line:
                 break
-            kv = line.strip().split(':', 1)
-            key = kv[0].strip().replace('"','')
+            kv = line.strip().split(":", 1)
+            key = kv[0].strip().replace('"', "")
             if key in self.lang["messages"]:
                 blank = False
-                translation = self.lang["messages"][key].replace('\n','\\n').replace('"','\\"')
+                translation = (
+                    self.lang["messages"][key].replace("\n", "\\n").replace('"', '\\"')
+                )
                 self.output.append('        "{}": "{}",'.format(key, translation))
             elif self.add_missing_keys and key != "":
                 blank = False
                 value = kv[1].strip().rstrip(",")[1:-1]
                 self.output.append('        "{}": "{}",'.format(key, value))
             elif blank == False:
-                self.output.append('')
+                self.output.append("")
                 blank = True
-    
+
     def save(self):
-        out = open(self.out, 'w', encoding="utf8")
-        out.write('\n'.join(self.output))
+        out = open(self.out, "w", encoding="utf8")
+        out.write("\n".join(self.output))
         out.close()
-        
+
+
 if __name__ == "__main__":
     import argparse
-    
-    parser = argparse.ArgumentParser(description='This script will reformat a Babel style JSON for locales to match the en.json baseline formatting for git changes purposes.')
-    parser.add_argument('--en', metavar='en_path', type=str, 
-                        help='The path to the en.json locale.')
-    parser.add_argument('--lang', metavar='lang_path', type=str, 
-                        help='The path to the LANG.json locale to clean.')
-    parser.add_argument('--out', metavar='out_path', type=str, 
-                        help='The path to save the formatted file.')
-    parser.add_argument('-a', '--add-missing-keys', action="store_true",
-                        help='If a key is missing in the translation, copy original text from en.json to the output file.')
+
+    parser = argparse.ArgumentParser(
+        description="This script will reformat a Babel style JSON for locales to match the en.json baseline formatting for git changes purposes."
+    )
+    parser.add_argument(
+        "--en", metavar="en_path", type=str, help="The path to the en.json locale."
+    )
+    parser.add_argument(
+        "--lang",
+        metavar="lang_path",
+        type=str,
+        help="The path to the LANG.json locale to clean.",
+    )
+    parser.add_argument(
+        "--out",
+        metavar="out_path",
+        type=str,
+        help="The path to save the formatted file.",
+    )
+    parser.add_argument(
+        "-a",
+        "--add-missing-keys",
+        action="store_true",
+        help="If a key is missing in the translation, copy original text from en.json to the output file.",
+    )
 
     args = parser.parse_args()
     N = LocaleCleaner(args.en, args.lang, args.out, args.add_missing_keys)

--- a/CleanJSON.py
+++ b/CleanJSON.py
@@ -4,14 +4,14 @@ import json
 
 
 class LocaleCleaner:
-    def __init__(self, en, lang, out, add_missing_keys=False):
-        en_file = open(en, "r", encoding="utf8")
-        lang_file = open(lang, "r", encoding="utf8")
-        self.out = out
-        self.en = en_file.readlines()
-        self.lang = json.load(lang_file)
-        self.output = []
-        self.add_missing_keys = add_missing_keys
+    def __init__(self, en: str, lang: str, out: str, add_missing_keys: bool = False):
+        with open(en, "r", encoding="utf8") as en_file:
+            self.en: list = en_file.readlines()
+        with open(lang, "r", encoding="utf8") as lang_file:
+            self.lang: dict = json.load(lang_file)
+        self.out: str = out
+        self.output: list = []
+        self.add_missing_keys: bool = add_missing_keys
 
     def run(self):
         self.make_header()
@@ -64,9 +64,8 @@ class LocaleCleaner:
                 blank = True
 
     def save(self):
-        out = open(self.out, "w", encoding="utf8")
-        out.write("\n".join(self.output))
-        out.close()
+        with open(self.out, "w", encoding="utf8") as out:
+            out.write("\n".join(self.output))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change is to let the scripts to fill out the missing keys in the translation json file. Because for Traditional Chinese we have too many missing keys to add and I have a couple of people working on the translation overhaul, I want to make the task slightly easier by letting the scripts fill out the missing keys on the translation file.

This changeset also reformats the python file, and emits help messages if arguments are not complete.