### PR TITLE
fix(en): add missing LUT import failure keys

### DIFF
--- a/en.json
+++ b/en.json
@@ -929,6 +929,9 @@
         "Importer.Image.Stereo180": "Stereo 180° photo",
         "Importer.Image.LUT": "LUT",
 
+        "Importer.LUT.Failure.Heading": "Failed to Import LUT <color=hero.yellow>{image}</color>",
+        "Importer.LUT.Failure.Description": "Failed to import LUT due to the following:\n\n<color=hero.red>{error}</color>",
+
         "Importer.ImageVideo.LayoutPrompt": "What layout does it use?",
         "Importer.ImageVideo.LayoutHorizontalLR": "Side by Side LR",
         "Importer.ImageVideo.LayoutHorizontalRL": "Side by Side RL",


### PR DESCRIPTION
Adds the following missing keys that are currently used for LUT import failures:

- `Importer.LUT.Failure.Heading`
- `Importer.LUT.Failure.Description`

<img width="581" alt="Visual of implemented Importer.LUT.Failure.* locale keys" src="https://github.com/Yellow-Dog-Man/Locale/assets/20023996/07df5e24-0b95-4c9c-b218-b938146c708b">

**Visual of Implemented Locale**

Resolves #414 