### PR TITLE
meta: add translator badge request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/badge.yml
+++ b/.github/ISSUE_TEMPLATE/badge.yml
@@ -7,3 +7,5 @@ body:
       label: User ID
       description: Your User ID. You can see how to find it on the [wiki](https://wiki.resonite.com/User_ID#Finding_a_user_ID).
       placeholder: U-fX3pKe7AYYQ
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/badge.yml
+++ b/.github/ISSUE_TEMPLATE/badge.yml
@@ -1,0 +1,9 @@
+name: Request Translator badge
+description: Request a Translator badge if you've contributed the locale.
+body:
+  - type: input
+    id: userid
+    attributes:
+      label: User ID
+      description: Your User ID. You can see how to find it on the [wiki](https://wiki.resonite.com/User_ID#Finding_a_user_ID).
+      placeholder: U-fX3pKe7AYYQ


### PR DESCRIPTION
This PR adds an issue template to request a translator badge.

It makes it easier to request one, with a ready to use form that asks for the required info.

The initial `config.yml` already takes care of redirecting users to the main repo for general issues.