### PR TITLE
[EN] Added missing string for "Contacts.NoSession"

### DIFF
--- a/en.json
+++ b/en.json
@@ -649,6 +649,7 @@
         "Contacts.WriteMessage": "Write a message...",
 
         "Contacts.InSession": "In {name}",
+        "Contacts.NoSession": "Not in any session",
         "Contacts.InPrivate": "In Private World",
         "Contacts.InContactsOnly": "In Contacts Only World",
         "Contacts.InHidden": "In Hidden World",


### PR DESCRIPTION
This adds string for Contacts.NoSession.
Fixes [Yellow-Dog-Man/Resonite-Issues#155](https://github.com/Yellow-Dog-Man/Locale/issues/155)