### PR TITLE
fix(en): add missing image import failure keys

### DIFF
--- a/en.json
+++ b/en.json
@@ -936,6 +936,9 @@
         "Importer.Image.Stereo180": "Stereo 180° photo",
         "Importer.Image.LUT": "LUT",
 
+        "Importer.Image.Failure.Heading": "Failed to Import Image <color=hero.yellow>{image}</color>",
+        "Importer.Image.Failure.Description": "Failed to import the image due to the following:\n\n<color=hero.red>{error}</color>",
+        
         "Importer.LUT.Failure.Heading": "Failed to Import LUT <color=hero.yellow>{image}</color>",
         "Importer.LUT.Failure.Description": "Failed to import LUT due to the following:\n\n<color=hero.red>{error}</color>",
 


### PR DESCRIPTION
This adds the missing "image import failure" keys:

* `Importer.Image.Failure.Heading`
* `Importer.Image.Failure.Description`

These keys are used when an image should encounter any of the following failures:

* Is importing an unsupported memory asset type (i.e., is not a Bitmap2D, Bitmap3D, or BitmapCube).
* Is unable to strip out the image metadata if the user opt-in to the privacy setting "Strip image metadata on import."

This key set follows the same format as the `Importer.LUT.Failure.*` keys, so `Importer.Image.Failure.Heading` utilizes the `image` key value pair for the file name value and `Importer.Image.Failure.Description` utilizes the `error` key value pair for the error message valuen
