### PR TITLE
tweak(en): change FOV zoom desc to be app agnostic

### DIFF
--- a/en.json
+++ b/en.json
@@ -1742,7 +1742,7 @@
         "Settings.DesktopRenderSettings.FieldOfView.Description": "Use this to control the field of view (FOV) when in desktop mode. Larger values will give you wider view at the cost of greater distortion on the sides.",
 
         "Settings.DesktopRenderSettings.SprintFieldOfViewZoom": "Zoom FOV when sprinting",
-        "Settings.DesktopRenderSettings.SprintFieldOfViewZoom.Description": "When this option is enabled, Resonite will zoom your FOV when you are sprinting in <b>Desktop</b>.\nDisable the setting to remove the effect.\n<b>Does NOT</b> include effects found in User Generated Content.",
+        "Settings.DesktopRenderSettings.SprintFieldOfViewZoom.Description": "When this option is enabled, your FOV will be zoomed when you are sprinting in Desktop. Disable this setting to remove this effect.\n\nPlease note that this does <b>NOT</b> disable effects found in User Generated Content.",
         
         "Settings.DesktopRenderSettings.VSync": "VSync",
         "Settings.DesktopRenderSettings.VSync.Description": "When this option is enabled, the framerate will be synced with the refresh rate of your screen. Disabling this can render frames faster, but also cause visible tearing.\n\nThis can be useful when doing performance testing, as it will uncap the update and rendering speed.",


### PR DESCRIPTION
This changes the settings description for "Zoom FOV when sprinting" to be app agnostic to align that characteristic with other setting descriptions. The text was also tweaked to provide a better flow and format that fits with other descriptions.