### PR TITLE
EN minor grammar fixes, corrected typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Total keys: 2315
 If you'd like to contribute translations, create a fork of the repository, make the changes and **once they are ready** to be merged create a Pull Request, so the contributions can be checked and merged. You don't need to translate everything at once, if you cover part of the UI, the changes can be merged, with more translations coming later.
 
 ### Translating the Store descriptions
-If you're like, you can help translate the store descriptions as well (this is used on Steam for example), but we consider those highly optional since it's quite a lot of text. If you don't want to translate those, don't worry about them! The store descriptions do not count towards the translation completeness percentage and are provided in separate files.
+If you'd like, you can help translate the store descriptions as well (this is used on Steam for example), but we consider those highly optional since it's quite a lot of text. If you don't want to translate those, don't worry about them! The store descriptions do not count towards the translation completeness percentage and are provided in separate files.
 
 If you do translate them and you haven't added a credit yet, put your name in the regular .json file for translations of in-game strings, even if you haven't translated any in-game strings.
 

--- a/en.json
+++ b/en.json
@@ -1278,7 +1278,7 @@
         "Settings.OnlineStatusSettings.RememberTimespan" : "Remember status for",
         "Settings.OnlineStatusSettings.RememberTimespan.Description" : "Your last online status will be remembered only if you log in again within this timeframe. If you take longer than this, you'll start with your default status instead.",
         "Settings.OnlineStatusSettings.InvisibleRememberMode" : "Remember last invisible status",
-        "Settings.OnlineStatusSettings.InvisibleRememberMode.Description" : "This controls how is your last status remembered specifically if you were last set to Invisible. Otherwise this functions the same.\n\nThe invisible status has a separate setting for privacy reasons, to ensure that if you were last set to invisible, you can ensure that you'll stay invisible at the next login even if your other statuses are not remembered.",
+        "Settings.OnlineStatusSettings.InvisibleRememberMode.Description" : "This controls how your last status is remembered specifically if you were last set to Invisible. Otherwise this functions the same.\n\nThe invisible status has a separate setting for privacy reasons, to ensure that if you were last set to invisible, you can ensure that you'll stay invisible at the next login even if your other statuses are not remembered.",
         "Settings.OnlineStatusSettings.InvisibleRememberTimespan" : "Remember invisible status for",
         "Settings.OnlineStatusSettings.InvisibleRememberTimespan.Description" : "Your last invisible status will be remembered only if you log in again within this timeframe. If you take longer than this, you'll start with your default status instead.",
         "Settings.OnlineStatusSettings.AutoAwayTimespan" : "Switch to Away when idle for",
@@ -1391,19 +1391,19 @@
 
         "Settings.TrackingSmoothingSettings.HandPositionSmoothing": "Hand Position Smoothing",
         "Settings.TrackingSmoothingSettings.HandRotationSmoothing": "Hand Rotation Smoothing",
-        "Settings.TrackingSmoothingSettings.HandPositionSmoothing.Description": "When enabled, this controls how much is the hand position smoothed out. Typically this is helpful for users with tremors and other accessibility issues that cause jitter.",
-        "Settings.TrackingSmoothingSettings.HandRotationSmoothing.Description": "When enabled, this controls how much is the hand rotation smoothed out. Typically this is helpful for users with tremors and other accessibility issues that cause jitter.",
+        "Settings.TrackingSmoothingSettings.HandPositionSmoothing.Description": "When enabled, this controls how much the hand position is smoothed out. Typically this is helpful for users with tremors and other accessibility issues that cause jitter.",
+        "Settings.TrackingSmoothingSettings.HandRotationSmoothing.Description": "When enabled, this controls how much the hand rotation is smoothed out. Typically this is helpful for users with tremors and other accessibility issues that cause jitter.",
 
         "Settings.TrackingSmoothingSettings.FeetPositionSmoothing": "Feet Position Smoothing",
         "Settings.TrackingSmoothingSettings.FeetRotationSmoothing": "Feet Rotation Smoothing",
 
-        "Settings.TrackingSmoothingSettings.FeetPositionSmoothing.Description": "When enabled, this controls how much is the position of feet smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
-        "Settings.TrackingSmoothingSettings.FeetRotationSmoothing.Description": "When enabled, this controls how much is the rotation of feet smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
+        "Settings.TrackingSmoothingSettings.FeetPositionSmoothing.Description": "When enabled, this controls how much the position of feet is smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
+        "Settings.TrackingSmoothingSettings.FeetRotationSmoothing.Description": "When enabled, this controls how much the rotation of feet is smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
 
         "Settings.TrackingSmoothingSettings.HipsPositionSmoothing": "Hips Position Smoothing",
         "Settings.TrackingSmoothingSettings.HipsRotationSmoothing": "Hips Rotation Smoothing",
-        "Settings.TrackingSmoothingSettings.HipsPositionSmoothing.Description": "When enabled, this controls how much is the position of hips smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
-        "Settings.TrackingSmoothingSettings.HipsRotationSmoothing.Description": "When enabled, this controls how much is the rotation of hips smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
+        "Settings.TrackingSmoothingSettings.HipsPositionSmoothing.Description": "When enabled, this controls how much the position of hips is smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
+        "Settings.TrackingSmoothingSettings.HipsRotationSmoothing.Description": "When enabled, this controls how much the rotation of hips is smoothed out when using full body tracking. This can be useful to eliminate vibrations and jitter, but it also makes the trackers lag behind more and not respond to rapid motions as well.",
 
         "Settings.MediaPrivacySettings": "Media Privacy",
         "Settings.MediaPrivacySettings.MediaMetadataOptOut": "Opt out of media metadata",
@@ -1594,10 +1594,10 @@
         "Settings.AudioInputFilteringSettings.NoiseGateRelease.Description": "This setting controls how fast the noise gate closes after the incoming audio has quieted again.",
 
         "Settings.AudioInputFilteringSettings.NormalizationThreshold": "Normalization threshold",
-        "Settings.AudioInputFilteringSettings.NormalizationThreshold.Description": "Using this setting you can control threshold when will the incoming audio become amplified. If your normal speech is too quiet and it's not getting amplified, lower this setting. If random quiet noises are being amplified, increase it.",
+        "Settings.AudioInputFilteringSettings.NormalizationThreshold.Description": "Using this setting you can control the threshold when the incoming audio will become amplified. If your normal speech is too quiet and it's not getting amplified, lower this setting. If random quiet noises are being amplified, increase it.",
 
         "Settings.AudioInputFilteringSettings.UseNoiseSuppression": "Noise suppression (RNNoise)",
-        "Settings.AudioInputFilteringSettings.UseNoiseSuppression.Description": "This feature processes the incoming audio to filter out various undesirable noises. This can clean up audio from noisy microphones considerably produce a cleaner voice. We strongly recommend keeping this setting on. However it can also filter certain noises that do not get identified as a speech.",
+        "Settings.AudioInputFilteringSettings.UseNoiseSuppression.Description": "This feature processes the incoming audio to filter out various undesirable noises. This can clean up audio from noisy microphones considerably, producing a cleaner voice. We strongly recommend keeping this setting on. However, it can also filter out certain noises that do not get identified as speech.",
 
         "Settings.VoiceSettings": "Voice Settings",
         "Settings.VoiceSettings.MutePersistence": "Mute Persistence",
@@ -1735,7 +1735,7 @@
         "Settings.LaserSettings.ModulateStartAngle": "Modulate start angle",
         "Settings.LaserSettings.ModulateStartAngle.Description": "This indicates the angle at which the laser smoothing speed will start modulating to catch up to your movements. Increasing this value will require larger movements for the laser to start catching up.",
         "Settings.LaserSettings.ModulateEndAngle": "Modulate end angle",
-        "Settings.LaserSettings.ModulateEndAngle.Description": "Related to the modulate start angle, this indicates when will the modulation reach maximum speed. By changing the start and end angles, you can control how responsive the laser is the more you move your hand.",
+        "Settings.LaserSettings.ModulateEndAngle.Description": "Related to the modulate start angle, this indicates when the modulation will reach maximum speed. By changing the start and end angles, you can control how responsive the laser is the more you move your hand.",
         "Settings.LaserSettings.ModulateExponent": "Modulate exponent",
         "Settings.LaserSettings.ModulateExponent.Description": "This controls the response curve of the laser modulation between the start and end angles. You can use this to either make the laser respond more sluggishly at first or to start responding quickly and then tapering off.",
         "Settings.LaserSettings.ModulateSpeedMultiplier": "Modulate speed multiplier",
@@ -1787,7 +1787,7 @@
         "Settings.DesktopRenderSettings.MaximumBackgroundFramerate.Description": "This determines the allowed maximum framerate while in background. Lower values will conserve more system resources.",
 
         "Settings.InteractiveCameraFramingSettings.PositioningMode": "Positioning mode",
-        "Settings.InteractiveCameraFramingSettings.PositioningMode.Description": "This controls how is the interactive camera positioned in the world.",
+        "Settings.InteractiveCameraFramingSettings.PositioningMode.Description": "This controls how the interactive camera is positioned in the world.",
         "Settings.InteractiveCameraFramingSettings.FieldOfView": "Field of view",
         "Settings.InteractiveCameraFramingSettings.FieldOfView.Description": "The field of view of the interactive camera. Higher values will capture more of the scene at the cost of distortion at the edges.",
         "Settings.InteractiveCameraFramingSettings.AnglePosition": "Angle",
@@ -1831,7 +1831,7 @@
         "Settings.InteractiveCameraSmoothingSettings.AngleSmoothSpeed": "Angle smoothing speed",
         "Settings.InteractiveCameraSmoothingSettings.AngleSmoothSpeed.Description": "This indicates how quickly does the camera respond to change in angle around the target subject.",
         "Settings.InteractiveCameraSmoothingSettings.FramingSmoothSpeed": "Framing smoothing speed",
-        "Settings.InteractiveCameraSmoothingSettings.FramingSmoothSpeed.Description": "This controls how fast is the camera adjusting its framing of the target subject. Larger values will make it track the target faster, but also result in more jerky movements.",
+        "Settings.InteractiveCameraSmoothingSettings.FramingSmoothSpeed.Description": "This controls how fast the camera adjusts its framing of the target subject. Larger values will make it track the target faster, but also result in more jerky movements.",
 
         "Settings.InteractiveCameraAnchorSettings.InterpolateBetweenAnchors": "Interpolate between anchors",
         "Settings.InteractiveCameraAnchorSettings.InterpolateBetweenAnchors.Description": "When enabled, camera will smoothly interpolate between camera anchors in the world.",
@@ -1855,7 +1855,7 @@
         "Settings.RelaySettings.AlwaysUseRelay": "Always use relay to connect",
         "Settings.RelaySettings.AlwaysUseRelay.Description": "Relays are typically used as a fallback when a direct connection to the host cannot be established. By enabling this option, you will force the connection to always happen through a relay.\n\nThis can be useful in cases of connection issues to particular hosts. It is <b>NOT</b> recommended to have this option permanently on.",
         "Settings.RelaySettings.UseClosestAvailableRelay": "Use closest available relay",
-        "Settings.RelaySettings.UseClosestAvailableRelay.Description": "When this option is enabled an available relay that is the closest to you will automatically be selected for the connection. If you want to connect through a specific relay (e.g. in case of long distance connections to avoid packet queuing) you can disable this option and configure the preferred relays below.",
+        "Settings.RelaySettings.UseClosestAvailableRelay.Description": "When this option is enabled the closest available relay will be automatically selected. If you want to connect through a specific relay (e.g. in case of long distance connections to avoid packet queuing) you can disable this option and configure the preferred relays below.",
         "Settings.RelaySettings.RelayPriorities": "Configure relay server priorities",
         "Settings.RelaySettings.RelayPriorities.Breadcrumb": "Relay Priorities",
 


### PR DESCRIPTION
There were a few strings with confusing grammar consisting of a question being used as a statement. 
I think it's called a subject-auxiliary verb inversion? I'm not a linguistics major though, so I'm not sure.

Example below:
Old version:
 - this controls when is [something] changed
New version:
 - this controls when [something] is changed

Additionally, I fixed a minor typo in the readme, and a few instances of confusing wording. These are minor changes but should make things easier to read and understand.