### PR TITLE
Fix typo in key Settings.KeyboardLookSettings.VerticalSpeed

### DIFF
--- a/de.json
+++ b/de.json
@@ -1386,7 +1386,7 @@
         "Settings.KeyboardLookSettings.LookEnabled.Description": "Wenn diese Funktion aktiv ist, können Sie Ihren Kopf mit den Pfeiltasten Ihrer Tastatur bewegen.<br/>Dies ist für Situationen gedacht, in denen eine Maus nicht vorhanden oder nicht zweckmäßig ist, z. B. bei der Verwendung eines Laptops oder wenn barrierefreie Alternativen zur Maus benötigt werden.",
         "Settings.KeyboardLookSettings.HorizontalSpeed": "Horizontale Geschwindigkeit der Tastatur-Blicksteuerung",
         "Settings.KeyboardLookSettings.HorizontalSpeed.Description": "Hier können Sie einstellen, wie schnell sich Ihr Kopf horizontal bewegt, wenn Sie die Tastatur-Blicksteuerung verwenden.",
-        "Settings.KeyboardLookSettings.VericalSpeed": "Vertikale Geschwindigkeit der Tastatur-Blicksteuerung",
+        "Settings.KeyboardLookSettings.VerticalSpeed": "Vertikale Geschwindigkeit der Tastatur-Blicksteuerung",
         "Settings.KeyboardLookSettings.VerticalSpeed.Description": "Diese Einstellung bestimmt, wie schnell sich Ihr Kopf vertikal bewegt, wenn Sie die Tastatur-Blicksteuerung verwenden.",
 
         "Settings.GeneralHapticsSettings.EnableControllerVibration": "Controller-Vibration",

--- a/en.json
+++ b/en.json
@@ -1387,7 +1387,7 @@
         "Settings.KeyboardLookSettings.LookEnabled.Description": "When enabled, Keyboard Look allows you to move your head around using the arrow keys on your keyboard. <br/> It is designed for scenarios when a Mouse might not be available or suitable such as when using a laptop or when accessible alternatives to a Mouse are required.",
         "Settings.KeyboardLookSettings.HorizontalSpeed": "Horizontal Speed for Keyboard Looking.",
         "Settings.KeyboardLookSettings.HorizontalSpeed.Description": "Use this to adjust how fast your head moves horizontally when using Keyboard Look.",
-        "Settings.KeyboardLookSettings.VericalSpeed": "Vertical Speed for Keyboard Looking.",
+        "Settings.KeyboardLookSettings.VerticalSpeed": "Vertical Speed for Keyboard Looking.",
         "Settings.KeyboardLookSettings.VerticalSpeed.Description": "Use this to adjust how fast your head moves vertically when using Keyboard Look.",
 
         "Settings.GeneralHapticsSettings.EnableControllerVibration": "Controller vibration",

--- a/fr.json
+++ b/fr.json
@@ -1386,7 +1386,7 @@
         "Settings.KeyboardLookSettings.LookEnabled.Description": "Quand activé, la vue par clavier vous permet de bouger votre vue a l'aide de votre clavier à la place de votre souris.<br>Cette option est utile dans des cas ou une souris n'est pas disponible ou si un périphérique plus accessible qu'une souris est utilisé.",
         "Settings.KeyboardLookSettings.HorizontalSpeed": "Vitesse horizontale.",
         "Settings.KeyboardLookSettings.HorizontalSpeed.Description": "Règle la vitesse horizontale de la vue par clavier.",
-        "Settings.KeyboardLookSettings.VericalSpeed": "Vitesse verticale.",
+        "Settings.KeyboardLookSettings.VerticalSpeed": "Vitesse verticale.",
         "Settings.KeyboardLookSettings.VerticalSpeed.Description": "Règle la vitesse verticale de la vue par clavier.",
 
         "Settings.GeneralHapticsSettings.EnableControllerVibration": "Vibration des manettes",

--- a/ja.json
+++ b/ja.json
@@ -1386,7 +1386,7 @@
         "Settings.KeyboardLookSettings.LookEnabled.Description": "この設定を有効にすると、キーボードの矢印キーを使って視点を動かすことができます。<br/>この機能は、ノートパソコンの使用時などマウスが使用できないか、適していない場合に、マウスに代わる操作が必要な場合のために設計されています。",
         "Settings.KeyboardLookSettings.HorizontalSpeed": "キーボードルックの水平移動速度",
         "Settings.KeyboardLookSettings.HorizontalSpeed.Description": "キーボードルック使用時の、視点が水平移動する速度を調整できます。",
-        "Settings.KeyboardLookSettings.VericalSpeed": "キーボードルックの上下移動速度",
+        "Settings.KeyboardLookSettings.VerticalSpeed": "キーボードルックの上下移動速度",
         "Settings.KeyboardLookSettings.VerticalSpeed.Description": "キーボードルック使用時の、視点が上下する移動の速さを調整します。",
 
         "Settings.GeneralHapticsSettings.EnableControllerVibration": "コントローラーの振動機能を使う",

--- a/nl.json
+++ b/nl.json
@@ -1386,7 +1386,7 @@
         "Settings.KeyboardLookSettings.LookEnabled.Description": "Wanneer dit aanstaat, kan je rondkijken met de pijltjestoetsen op het toetsenbord. <br/> Dit is bedoeld voor als een muis niet beschikbaar of geschikt is, zoals op een laptop of wanneer toegankelijke alternatieven benodigd zijn.",
         "Settings.KeyboardLookSettings.HorizontalSpeed": "Horizontale Snelheid",
         "Settings.KeyboardLookSettings.HorizontalSpeed.Description": "Gebruik dit om aan te passen hoe snel je hoofd horizontaal draait wanneer je rondkijkt met het toetsenbord.",
-        "Settings.KeyboardLookSettings.VericalSpeed": "Verticale Snelheid",
+        "Settings.KeyboardLookSettings.VerticalSpeed": "Verticale Snelheid",
         "Settings.KeyboardLookSettings.VerticalSpeed.Description": "Gebruik dit om aan te passen hoe snel je hoofd verticaal draait wanneer je rondkijkt met het toetsenbord.",
 
         "Settings.GeneralHapticsSettings.EnableControllerVibration": "Controller trillingen",

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1386,7 +1386,7 @@
         "Settings.KeyboardLookSettings.LookEnabled.Description": "启用后，键盘查看设置将允许你使用键盘上的箭头键移动你的头部。 <br/> 该功能是用于在一些无法或者不适合使用鼠标的场景，例如使用笔记本电脑或者其他需要使用鼠标的替代方案。",
         "Settings.KeyboardLookSettings.HorizontalSpeed": "键盘观察的水平速度。",
         "Settings.KeyboardLookSettings.HorizontalSpeed.Description": "使用键盘观察时，使用它来调整头部水平移动的速度。",
-        "Settings.KeyboardLookSettings.VericalSpeed": "键盘观察的垂直速度。",
+        "Settings.KeyboardLookSettings.VerticalSpeed": "键盘观察的垂直速度。",
         "Settings.KeyboardLookSettings.VerticalSpeed.Description": "使用键盘观察时，使用它来调整头部垂直移动的速度。",
 
         "Settings.GeneralHapticsSettings.EnableControllerVibration": "控制器振动",


### PR DESCRIPTION
Resonite uses the key Settings.KeyboardLookSettings.VerticalSpeed, but there is a typo in the locale where this is Settings.KeyboardLookSettings.VericalSpeed.

This fixes the key in the locale to be correct to what Resonite uses.