### PR TITLE
Added missing AudioStreamSettings strings

### DIFF
--- a/en.json
+++ b/en.json
@@ -1294,6 +1294,10 @@
         "Settings.AudioAccessibilitySettings": "Audio Accessibility",
         "Settings.AudioInputFilteringSettings": "Input Filtering",
 
+        "Settings.AudioStreamSettings": "Audio Stream Settings",
+        "Settings.AudioStreamSettings.DefaultBitrate": "Default bitrate",
+        "Settings.AudioStreamSettings.DefaultDeviceID": "Default Device-ID",
+
         "Settings.RealtimeNetworkingSettings": "Realtime Networking",
         "Settings.AssetGatherSettings": "Asset Gathering",
 


### PR DESCRIPTION
These seem to be around for quite a while now and seem to be forgotten in the base locale?
Updated them.
Unless I happened to have missed the memo that these shouldn't be there.

![image](https://github.com/user-attachments/assets/8bb19c83-f6b0-41df-aeed-0758f0935a81)
