### PR TITLE
Remove references to "Patreon"

### DIFF
--- a/en.json
+++ b/en.json
@@ -359,7 +359,7 @@
         "World.Edit.Path": "World Path:",
         "World.Edit.AccessLevelHeader": "Who can open this world?",
         "World.Edit.AccessPrivate": "Only Me",
-        "World.Edit.AccessPatreon": "Patreon Supporters",
+        "World.Edit.AccessPatreon": "{platform} Supporters",
         "World.Edit.AccessPublic": "Anyone (public)",
         "World.Edit.ReadOnly": "ReadOnly",
 
@@ -585,7 +585,7 @@
 
         "Account.Type.Standard": "Standard Account",
         "Account.Type.Business": "Business Account",
-        "Account.Type.Patreon": "Patreon Supporter",
+        "Account.Type.Patreon": "{platform} Supporter",
         "Account.Type.Mentor": "{platform} Mentor",
         "Account.Type.Moderator": "{platform} Moderator",
         "Account.Type.Team": "{platform} Team",


### PR DESCRIPTION
Replaced "Patreon Supporter(s)" with "{platform} Supporter(s)".

Relevant to issue: #645

>On the dash the account type shows "Patreon Supporter" when subscribed with stripe.
>
>One solution would be to remove all references to "Patreon Supporter" and replace it with >"{platform} Supporter"/"Resonite Supporter" or just "Supporter".