### PR TITLE
"Starte Sitzung" -> "Sitzung starten"

### DIFF
--- a/de.json
+++ b/de.json
@@ -230,7 +230,7 @@
         "World.Config.CleanupAssets": "Bereinigung nicht verwendeter Assets:",
         "World.Config.CleanupInterval": "Intervall für automatische Bereinigung [Sekunden]:",
 
-        "World.Actions.StartSession": "Starte Sitzung",
+        "World.Actions.StartSession": "Sitzung starten",
         "World.Actions.Join": "Beitreten",
         "World.Actions.Focus": "Fokussieren",
         "World.Actions.Close": "Welt schließen",


### PR DESCRIPTION
It sounds more natural this way because the old one is in the imperative case.