### PR TITLE
Remove "Settings" from Video Streaming Services settings header

### DIFF
--- a/en.json
+++ b/en.json
@@ -1983,7 +1983,7 @@
         "Settings.RelaySettings.RelayPriorities": "Configure relay server priorities",
         "Settings.RelaySettings.RelayPriorities.Breadcrumb": "Relay Priorities",
 
-        "Settings.VideoStreamingServicesSettings": "Video Streaming Services Settings",
+        "Settings.VideoStreamingServicesSettings": "Video Streaming Services",
         "Settings.VideoStreamingServicesSettings.UseCookiesFromBrowser": "Use Cookies From Browser",
         "Settings.VideoStreamingServicesSettings.UseCookiesFromBrowser.Description": "If YouTube and other service videos are not loading for you, select the browser you typically use to load cookies from when fetching those videos. This increases the chances of video loading successfully.",
 


### PR DESCRIPTION
Very minor change - this simply removes the word "Settings" from the end of the Video Streaming Services settings header for consistency with all other setting groups.