### PR TITLE
feat(ColorPicker): Add string for new Color Picker Blackbody tab

### DIFF
--- a/en.json
+++ b/en.json
@@ -2895,6 +2895,7 @@
         "UI.ColorPicker.Linear": "Linear",
 
         "UI.ColorPicker.Hexadecimal": "Hex",
+        "UI.ColorPicker.Blackbody": "Blackbody",
         "UI.ColorPicker.ColorSwatches": "Swatch",
 
         "UI.ColorPicker.Red": "Red",


### PR DESCRIPTION
Added a string for the upcoming Blackbody color picker type for the default Color Picker.

This is in conjunction with [#2392](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2392) requested by PointerOffset, where the in-world side of this changes has already been created and is ready for deployment once the locale string here is pushed.

Here is what the new edit type looks like on the Color Picker (and the text for this locale PR!), by the way:
![2025-05-24_23-45-51](https://github.com/user-attachments/assets/655a13f2-5ab5-44c3-800a-70fad4ccc511)
