### PR TITLE
zh-cn:烬夜新生

### DIFF
--- a/zh-cn.json
+++ b/zh-cn.json
@@ -2367,6 +2367,7 @@
 
         "Inspector.CharacterController.Warning": "<color=red><size=150%>警告！</size></color><br>当勾选模拟旋转（SimulateRotation）时这个组件可以被当作一个简单的刚体。在你这样做之前，你需要明白它不曾为此优化，且对刚体的正式支持会在未来加入。<br>正式支持包括：<br><b>- CPU和网络效率提升</b> - 使用角色控制器，你的CPU和网络占用会显著上升<br><b>- 约束</b> - 你将能够在刚体间创建关节、合页、弹簧和其他约束<br><b>- 对每个人的平滑模拟与交互</b> - 在另一个人尝试交互时，角色控制器会发生故障<br><b>- 新功能与工具</b> - 让使用更加简单<br>-----------------------<br>只要你理解了上述限制，放开玩吧！",
         "Inspector.PrimitiveMemberEditor.Warning": "<color=red><size=150%>警告!</size></color><br>通过他们的ID，这个组件可以被用于与引用交互。这个过程常被称为“引用骇入”。<br><br>在你这样做<b>之前</b>，请知晓这种方式 <b>不被</b> 支持且随时可能失效。请勿让你的作品依赖于此项功能。",
+        "Inspector.FacetPreset.Warning":"<color=red><size=125%>警告!</size></color><br>Facet预设将会在我们发布新版本的时候自动更新。如果你在用自定义版本呢，我们建议删除这个组件。",
 
         "Inspector.ParticleSystem.BasicInfo" : "粒子： {count}， 帧率： {fps}， 模拟时间： {time}， 提交时间： {renderSubmitTime}， 渲染分配： {allocationCount}",
         "Inspector.ParticleSystem.TrailInfo" : "尾迹： {trailCount} (容量： {trailCapacity}), 尾迹点容量： {trailPointCapacity}",


### PR DESCRIPTION
I hope you don't mind the small problem happeded few days ago. 
Now I need to let you know our team's current attitude so I will sometimes add some story in the description. Then you will know. Majority conversation was made my one of our member. Or someone else.
![image](https://github.com/user-attachments/assets/a6940418-3ca1-4ff3-bf9a-a3951c9940df)
![image](https://github.com/user-attachments/assets/2a9a68fd-17c4-4bc1-94e4-4220298abf40)
![image](https://github.com/user-attachments/assets/43e2512e-3aa5-4bc7-b186-179b32035fc2)
Here is the translations. It's kind of important but it's up to you.
You probably thinking VRC is bad.
But this is the best.
Since creator tool and platform.
This is what I experienced result when I investigate other "competitors" and tried to migrate to Resonite.
There are some benefits from VRC that other platform cannot provide.
First, there is the in-depth integration of Unity. Although Udon is really bad Unity, as an industrial-grade game development platform, has a large number of mature solutions.
These tools are working on unity very well. So it's possible to migrated platform.
Another point of view is that it's not develop for VRC. It's for unity.
They think the chicken are born from the air. But they ignore the goose who's laying eggs.
Player B:I think it doesn't really bad. I just have a kind of feeling that VRC do have lots of restriction. I'm looking forward to the premium can reach them.
Besides VRC provided unlimited managed assets
You gonna know these assets' size is really huge.
But whatever is the world or avatar, there's not upload restriction.
Player C: Yes. Managed asset costs is VRC's invincible sheild
The size of the world is limited by the LZ4 of the assetbundle, which can only be 4GB before compression. The size of the avatar is limited by the performance strategy
These two points makes NO COMPETITORS on the market.
If every art creator must pay for their own managed assets, there's no such low barrier for creators.
When promoting the detachment of one's own assets from VRC, one cannot ignore VRC's unconditional free managed assets.
END
Sometimes I do need to open my eyes and mind.