### PR TITLE
Fix typo in Vistor

### DIFF
--- a/Missing/en-gb.md
+++ b/Missing/en-gb.md
@@ -512,7 +512,7 @@ Session.Tab.Settings
 Session.Tab.Users  
 Session.Tab.Permissions  
 Session.Permission.Anonymous  
-Session.Permission.Vistor  
+Session.Permission.Visitor  
 Session.Permission.Contact  
 Session.Permission.Host  
 Session.Permission.PermissionOverrideCount  

--- a/Missing/th.md
+++ b/Missing/th.md
@@ -463,7 +463,7 @@ Session.Tab.Settings
 Session.Tab.Users  
 Session.Tab.Permissions  
 Session.Permission.Anonymous  
-Session.Permission.Vistor  
+Session.Permission.Visitor  
 Session.Permission.Contact  
 Session.Permission.Host  
 Session.Permission.PermissionOverrideCount  

--- a/cs.json
+++ b/cs.json
@@ -575,7 +575,7 @@
         "Session.Tab.Permissions": "Práva",
 
         "Session.Permission.Anonymous": "Výchozí anonym:",
-        "Session.Permission.Vistor": "Výchozí návštěvník:",
+        "Session.Permission.Visitor": "Výchozí návštěvník:",
         "Session.Permission.Contact": "Vychozí kontakt:",
         "Session.Permission.Host": "Výchozí host:",
         "Session.Permission.PermissionOverrideCount": "Počet uživatelů s individuálními právy: {n,select, -1 {---} other {{n}}}",

--- a/de.json
+++ b/de.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "Berechtigungen",
 
         "Session.Permission.Anonymous": "Standard Anonym:",
-        "Session.Permission.Vistor": "Standard Besucher:",
+        "Session.Permission.Visitor": "Standard Besucher:",
         "Session.Permission.Contact": "Standard Kontakt:",
         "Session.Permission.Host": "Standard Host:",
         "Session.Permission.PermissionOverrideCount": "Rechte-{n, plural, one {Übersteuerung} other {Übersteuerungen}}: {n, select, -1 {---} other {{n}}}",

--- a/en.json
+++ b/en.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "Permissions",
 
         "Session.Permission.Anonymous": "Default Anonymous:",
-        "Session.Permission.Vistor": "Default Visitor:",
+        "Session.Permission.Visitor": "Default Visitor:",
         "Session.Permission.Contact": "Default Contact:",
         "Session.Permission.Host": "Default Host:",
         "Session.Permission.PermissionOverrideCount": "Permission Overrides: {n,select, -1 {---} other {{n}}}",

--- a/eo.json
+++ b/eo.json
@@ -594,7 +594,7 @@
         "Session.Tab.Permissions": "Permesoj",
 
         "Session.Permission.Anonymous": "Defaŭlta Anonimulo:",
-        "Session.Permission.Vistor": "Defaŭlta Vizitanto:",
+        "Session.Permission.Visitor": "Defaŭlta Vizitanto:",
         "Session.Permission.Contact": "Defaŭlta Kontakto:",
         "Session.Permission.Host": "Defaŭlta Gastiganto:",
         "Session.Permission.PermissionOverrideCount": "Superregitaj Permesoj: {n,select, -1 {---} other {{n}}}",

--- a/es.json
+++ b/es.json
@@ -607,7 +607,7 @@
         "Session.Tab.Permissions": "Opciones de Permisos",
 
         "Session.Permission.Anonymous": "Usuario Anónimo:",
-        "Session.Permission.Vistor": "Usuario Visitor:",
+        "Session.Permission.Visitor": "Usuario Visitor:",
         "Session.Permission.Contact": "Contactos:",
         "Session.Permission.Host": "Anfitrión:",
         "Session.Permission.PermissionOverrideCount": "Permisos Sobreescritos: {n,select, -1 {---} other {{n}}}",

--- a/et.json
+++ b/et.json
@@ -351,7 +351,7 @@
         "Session.Tab.Permissions": "Kasutajate õigused",
 
         "Session.Permission.Anonymous": "Anonüümne külastaja on vaikimisi:",
-        "Session.Permission.Vistor": "Tavaline külaline on vaikimisi:",
+        "Session.Permission.Visitor": "Tavaline külaline on vaikimisi:",
         "Session.Permission.Contact": "Kontaktid on vaikimisi:",
         "Session.Permission.Host": "Peremees on vaikimisi:",
         "Session.Permission.PermissionOverrideCount": "Loa ülekirjutis: {n,select, -1 {---} other {{n}}}",

--- a/fi.json
+++ b/fi.json
@@ -614,7 +614,7 @@
         "Session.Tab.Permissions": "Käyttöoikeudet",
 
         "Session.Permission.Anonymous": "Oletus anonyymi:",
-        "Session.Permission.Vistor": "Oletus vierailija:",
+        "Session.Permission.Visitor": "Oletus vierailija:",
         "Session.Permission.Contact": "Oletus kontakti:",
         "Session.Permission.Host": "Oletus isäntä:",
         "Session.Permission.PermissionOverrideCount": "Käyttäjien erikoisluvat: {n,select, -1 {---} other {{n}}}",

--- a/fr.json
+++ b/fr.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "Permissions",
 
         "Session.Permission.Anonymous": "Anonyme, par défaut:",
-        "Session.Permission.Vistor": "Visiteur, par défaut:",
+        "Session.Permission.Visitor": "Visiteur, par défaut:",
         "Session.Permission.Contact": "Ami, par défaut:",
         "Session.Permission.Host": "Hôte, par défaut:",
         "Session.Permission.PermissionOverrideCount": "Permissions spéciales: {n,select, -1 {---} other {{n}}}",

--- a/hu.json
+++ b/hu.json
@@ -557,7 +557,7 @@
         "Session.Tab.Permissions": "Engedélyek",
 
         "Session.Permission.Anonymous": "Vendég alapbeállításai:",
-        "Session.Permission.Vistor": "Látogató alapbeállításai:",
+        "Session.Permission.Visitor": "Látogató alapbeállításai:",
         "Session.Permission.Contact": "Barát alapbeállításai:",
         "Session.Permission.Host": "Szobatulaj alapbeállításai:",
         "Session.Permission.PermissionOverrideCount": "Engedély átírása: {n,select, -1 {---} other {{n}}}",

--- a/is.json
+++ b/is.json
@@ -515,7 +515,7 @@
         "Session.Tab.Permissions": "Leyfi",
 
         "Session.Permission.Anonymous": "Sjálfgefið nafnlaus:",
-        "Session.Permission.Vistor": "Sjálfgefinn gestur:",
+        "Session.Permission.Visitor": "Sjálfgefinn gestur:",
         "Session.Permission.Contact": "Sjálfgefinn tengiliður:",
         "Session.Permission.Host": "Sjálfgefinn hýsandi:",
         "Session.Permission.PermissionOverrideCount": "Yfirskrifin leyfi: {n,select, -1 {---} other {{n}}}",

--- a/ja.json
+++ b/ja.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "権限",
 
         "Session.Permission.Anonymous": "未ログインユーザーの権限",
-        "Session.Permission.Vistor": "フレンドでないユーザーの権限",
+        "Session.Permission.Visitor": "フレンドでないユーザーの権限",
         "Session.Permission.Contact": "フレンドの権限",
         "Session.Permission.Host": "ホストユーザーの権限",
         "Session.Permission.PermissionOverrideCount": "個別に権限を設定したユーザー: {n,select, -1 {--表示できません--} other {{n}}}人",

--- a/ko.json
+++ b/ko.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "세션권한",
 
         "Session.Permission.Anonymous": "익명 사용자:",
-        "Session.Permission.Vistor": "가입자:",
+        "Session.Permission.Visitor": "가입자:",
         "Session.Permission.Contact": "친구:",
         "Session.Permission.Host": "호스트(방장):",
         "Session.Permission.PermissionOverrideCount": "권한승계: {n,select, -1 {---} other {{n}}}",

--- a/mn.json
+++ b/mn.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "Зөвшөөрөл",
 
         "Session.Permission.Anonymous": "Анхдагч нэргүй:",
-        "Session.Permission.Vistor": "Анхдагч зочин:",
+        "Session.Permission.Visitor": "Анхдагч зочин:",
         "Session.Permission.Contact": "Анхдагч харилцагч:",
         "Session.Permission.Host": "Анхдагч хост:",
         "Session.Permission.PermissionOverrideCount": "Зөвшөөрөл дарж бичилт: {n,select, -1 {---} other {{n}}}",

--- a/nl.json
+++ b/nl.json
@@ -610,7 +610,7 @@
         "Session.Tab.Permissions": "Rechten",
 
         "Session.Permission.Anonymous": "Standaard Anoniem:",
-        "Session.Permission.Vistor": "Standaard Bezoeker:",
+        "Session.Permission.Visitor": "Standaard Bezoeker:",
         "Session.Permission.Contact": "Standaard Contact:",
         "Session.Permission.Host": "Standaard Host:",
         "Session.Permission.PermissionOverrideCount": "Rechten Overschreven: {n,select, -1 {---} other {{n}}}",

--- a/no.json
+++ b/no.json
@@ -522,7 +522,7 @@
         "Session.Tab.Permissions": "Tillatelser",
 
         "Session.Permission.Anonymous": "Standard anonym:",
-        "Session.Permission.Vistor": "Standardbesøk:",
+        "Session.Permission.Visitor": "Standardbesøk:",
         "Session.Permission.Contact": "Standard kontakt:",
         "Session.Permission.Host": "Standard vert:",
         "Session.Permission.PermissionOverrideCount": "brukeroverstyringer: {n,select, -1 {---} other {{n}}}",

--- a/pl.json
+++ b/pl.json
@@ -614,7 +614,7 @@
         "Session.Tab.Permissions": "Uprawnienia",
 
         "Session.Permission.Anonymous": "Domyślny Anonim:",
-        "Session.Permission.Vistor": "Domyślny Odwiedzający:",
+        "Session.Permission.Visitor": "Domyślny Odwiedzający:",
         "Session.Permission.Contact": "Domyślny Kontakt:",
         "Session.Permission.Host": "Domyślny Host:",
         "Session.Permission.PermissionOverrideCount": "Nadpisane Uprawnienia: {n,select, -1 {---} other {{n}}}",

--- a/pt-br.json
+++ b/pt-br.json
@@ -521,7 +521,7 @@
         "Session.Tab.Permissions": "Permissões",
 
         "Session.Permission.Anonymous": "Padrão para Anonimos:",
-        "Session.Permission.Vistor": "Padrão para Visitantes:",
+        "Session.Permission.Visitor": "Padrão para Visitantes:",
         "Session.Permission.Contact": "Padrão para Contatos:",
         "Session.Permission.Host": "Padrões para Anfitriões:",
         "Session.Permission.PermissionOverrideCount": "Permissões Alteradas: {n,select, -1 {---} other {{n}}}",

--- a/ru.json
+++ b/ru.json
@@ -610,7 +610,7 @@
         "Session.Tab.Permissions": "Разрешения",
 
         "Session.Permission.Anonymous": "По умолчанию Аноним:",
-        "Session.Permission.Vistor": "По умолчанию Посетитель:",
+        "Session.Permission.Visitor": "По умолчанию Посетитель:",
         "Session.Permission.Contact": "По умолчанию Контакт:",
         "Session.Permission.Host": "По умолчанию Хост:",
         "Session.Permission.PermissionOverrideCount": "Переопределения разрешений: {n,select, -1 {---} other {{n}}}",

--- a/sv.json
+++ b/sv.json
@@ -595,7 +595,7 @@
         "Session.Tab.Permissions": "Behörigheter",
 
         "Session.Permission.Anonymous": "Standard Anonym:",
-        "Session.Permission.Vistor": "Standard Besökare:",
+        "Session.Permission.Visitor": "Standard Besökare:",
         "Session.Permission.Contact": "Standard Kontakt:",
         "Session.Permission.Host": "Standard Värd:",
         "Session.Permission.PermissionOverrideCount": "Åsidosatta Behörigheter: {n,select, -1 {---} other {{n}}}",

--- a/tr.json
+++ b/tr.json
@@ -325,7 +325,7 @@
         "Session.Tab.Permissions": "İzinler",
 
         "Session.Permission.Anonymous": "Varsayılan Anonim:",
-        "Session.Permission.Vistor": "Varsayılan Ziyaretçi:",
+        "Session.Permission.Visitor": "Varsayılan Ziyaretçi:",
         "Session.Permission.Contact": "Varsayılan İlgili Kişi:",
         "Session.Permission.Host": "Varsayılan Konak:",
         "Session.Permission.PermissionOverrideCount": "İzin Geçersiz Kılma: {n,select, -1 {---} other {{n}}}",

--- a/uk.json
+++ b/uk.json
@@ -606,7 +606,7 @@
         "Session.Tab.Permissions": "Дозволи",
 
         "Session.Permission.Anonymous": "Звичайний Анонім:",
-        "Session.Permission.Vistor": "Звичаний Гість:",
+        "Session.Permission.Visitor": "Звичаний Гість:",
         "Session.Permission.Contact": "Звичайний Контакт:",
         "Session.Permission.Host": "Звичайний Господар:",
         "Session.Permission.PermissionOverrideCount": "Перезапис Дозволів: {n,select, -1 {---} other {{n}}}",

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "权限",
 
         "Session.Permission.Anonymous": "匿名用户的默认权限：",
-        "Session.Permission.Vistor": "访客的默认权限：",
+        "Session.Permission.Visitor": "访客的默认权限：",
         "Session.Permission.Contact": "好友的默认权限：",
         "Session.Permission.Host": "主机的默认权限：",
         "Session.Permission.PermissionOverrideCount": "权限覆盖: {n,select, -1 {无} other {#}}",

--- a/zh-tw.json
+++ b/zh-tw.json
@@ -615,7 +615,7 @@
         "Session.Tab.Permissions": "權限",
 
         "Session.Permission.Anonymous": "預設匿名：",
-        "Session.Permission.Vistor": "預設訪客：",
+        "Session.Permission.Visitor": "預設訪客：",
         "Session.Permission.Contact": "預設好友：",
         "Session.Permission.Host": "預設主持：",
         "Session.Permission.PermissionOverrideCount": "權限覆蓋：{n,select, -1 {---} other {{n} 項}}",


### PR DESCRIPTION
there is a typo in the name of the translation key "Session.Permission.Vistor"