### PR TITLE
Help Tab: Added Strings For New Yearly Badges, Adjusted Headless Badge String

### DIFF
--- a/en.json
+++ b/en.json
@@ -3726,9 +3726,13 @@
         "Help.About.Badges.Accessibility.Mute": "Mute",
         "Help.About.Badges.Accessibility.Mute.Content": "This user is mute, or has otherwise chosen to not communicate verbally.",
 
+        "Help.About.Badges.Yearly.2017.Content": "This user registered their account in 2017.",
         "Help.About.Badges.Yearly.2018.Content": "This user registered their account in 2018.",
         "Help.About.Badges.Yearly.2019.Content": "This user registered their account in 2019.",
         "Help.About.Badges.Yearly.2020.Content": "This user registered their account in 2020.",
+        "Help.About.Badges.Yearly.2021.Content": "This user registered their account in 2021.",
+        "Help.About.Badges.Yearly.2022.Content": "This user registered their account in 2022.",
+        "Help.About.Badges.Yearly.2023.Content": "This user registered their account in 2023 - the year {appName} released.",
 
         "Help.About.Badges.Account.Supporter": "Supporter",
         "Help.About.Badges.Account.Supporter.Content": "This user is supporting the platform monetarily, or has supported in the past.",
@@ -3738,7 +3742,8 @@
         "Help.About.Badges.Hosting.Host": "Host",
         "Help.About.Badges.Hosting.Host.Content": "This user is hosting the current session you're in.",
         "Help.About.Badges.Hosting.HeadlessClient": "Headless Client",
-        "Help.About.Badges.Hosting.HeadlessClient.Content": "This user is a client which hosts sessions but doesn't have any user behind it.",
+        "Help.About.Badges.Hosting.HeadlessClient.Content": "This user is a client which hosts sessions but doesn't have a presence in the world.",
+
         "Help.About.Badges.Misc.Linux.Content": "This user is running on a Linux distribution.",
         "Help.About.Badges.Misc.Durian.Content": "This user participated in the pre-release phase of {appName}.",
         "Help.About.Badges.Misc.Potato": "Potato",


### PR DESCRIPTION
With the upcoming addition of newer yearly badges and other badge refreshes, this PR adds their relevant strings to the Help tab. I also mildly adjusted the wording for the headless badge.