### PR TITLE
Add Linux platform-specific setting strings

### DIFF
--- a/en.json
+++ b/en.json
@@ -1366,6 +1366,7 @@
         "Settings.UserRestrictionsSettings": "User Restrictions",
 
         "Settings.WindowsSettings": "Windows Settings",
+        "Settings.LinuxSettings": "Linux Settings",
         "Settings.DebugSettings": "Debug",
         "Settings.LegacyFeatureSettings": "Legacy Features",
         "Settings.TwitchInterfaceSettings": "Twitch Streaming Interface",
@@ -1747,6 +1748,9 @@
 
         "Settings.WindowsSettings.KeepOriginalScreenshotFormat": "Keep original screenshot format",
         "Settings.WindowsSettings.KeepOriginalScreenshotFormat.Description": "Enable this to avoid converting captured screenshots to JPG or PNG when saving them to the Documents folder in Windows. This can make them more difficult to use, as some apps might not be able to open the format.",
+
+        "Settings.LinuxSettings.KeepOriginalScreenshotFormat": "Keep original screenshot format",
+        "Settings.LinuxSettings.KeepOriginalScreenshotFormat.Description": "Enable this to avoid converting captured screenshots to JPG or PNG when saving them to the Pictures folder in Linux. This can make them more difficult to use, as some apps might not be able to open the format.",
 
         "Settings.DebugSettings.DebugInputBindings": "Debug input bindings",
         "Settings.DebugSettings.DebugInputBindings.Description": "When enabled, you will see debugging information for the input binding system. This is mostly useful for developers.",

--- a/en.json
+++ b/en.json
@@ -1365,8 +1365,7 @@
         "Settings.HostAccessSettings": "Host Access",
         "Settings.UserRestrictionsSettings": "User Restrictions",
 
-        "Settings.WindowsSettings": "Windows Settings",
-        "Settings.LinuxSettings": "Linux Settings",
+        "Settings.OsSettings": "OS Settings",
         "Settings.DebugSettings": "Debug",
         "Settings.LegacyFeatureSettings": "Legacy Features",
         "Settings.TwitchInterfaceSettings": "Twitch Streaming Interface",
@@ -1746,11 +1745,8 @@
 
         "Settings.UserRestrictionsSettings.DebugReset": "Reset User Restrictions",
 
-        "Settings.WindowsSettings.KeepOriginalScreenshotFormat": "Keep original screenshot format",
-        "Settings.WindowsSettings.KeepOriginalScreenshotFormat.Description": "Enable this to avoid converting captured screenshots to JPG or PNG when saving them to the Documents folder in Windows. This can make them more difficult to use, as some apps might not be able to open the format.",
-
-        "Settings.LinuxSettings.KeepOriginalScreenshotFormat": "Keep original screenshot format",
-        "Settings.LinuxSettings.KeepOriginalScreenshotFormat.Description": "Enable this to avoid converting captured screenshots to JPG or PNG when saving them to the Pictures folder in Linux. This can make them more difficult to use, as some apps might not be able to open the format.",
+        "Settings.OsSettings.KeepOriginalScreenshotFormat": "Keep original screenshot format",
+        "Settings.OsSettings.KeepOriginalScreenshotFormat.Description": "Enable this to avoid converting captured screenshots to JPG or PNG when saving them to the Pictures folder on your hard drive. This can make them more difficult to use, as some apps might not be able to open the format.",
 
         "Settings.DebugSettings.DebugInputBindings": "Debug input bindings",
         "Settings.DebugSettings.DebugInputBindings.Description": "When enabled, you will see debugging information for the input binding system. This is mostly useful for developers.",

--- a/en.json
+++ b/en.json
@@ -1365,7 +1365,7 @@
         "Settings.HostAccessSettings": "Host Access",
         "Settings.UserRestrictionsSettings": "User Restrictions",
 
-        "Settings.OsSettings": "OS Settings",
+        "Settings.OperatingSystemSettings": "OS Settings",
         "Settings.DebugSettings": "Debug",
         "Settings.LegacyFeatureSettings": "Legacy Features",
         "Settings.TwitchInterfaceSettings": "Twitch Streaming Interface",
@@ -1745,8 +1745,8 @@
 
         "Settings.UserRestrictionsSettings.DebugReset": "Reset User Restrictions",
 
-        "Settings.OsSettings.KeepOriginalScreenshotFormat": "Keep original screenshot format",
-        "Settings.OsSettings.KeepOriginalScreenshotFormat.Description": "Enable this to avoid converting captured screenshots to JPG or PNG when saving them to the Pictures folder on your hard drive. This can make them more difficult to use, as some apps might not be able to open the format.",
+        "Settings.OperatingSystemSettings.KeepOriginalScreenshotFormat": "Keep original screenshot format",
+        "Settings.OperatingSystemSettings.KeepOriginalScreenshotFormat.Description": "Enable this to avoid converting captured screenshots to JPG or PNG when saving them to the Pictures folder on your hard drive. This can make them more difficult to use, as some apps might not be able to open the format.",
 
         "Settings.DebugSettings.DebugInputBindings": "Debug input bindings",
         "Settings.DebugSettings.DebugInputBindings.Description": "When enabled, you will see debugging information for the input binding system. This is mostly useful for developers.",


### PR DESCRIPTION
Swaps the Windows-specific keys to be more OS-agnostic.

The pipeline is failing as it hasn't been changed for other languages.