### PR TITLE
CleanJSON.py: force unix-style newline

### DIFF
--- a/CleanJSON.py
+++ b/CleanJSON.py
@@ -53,7 +53,7 @@ class LocaleCleaner:
                 blank = True
     
     def save(self):
-        out = open(self.out, 'w', encoding="utf8")
+        out = open(self.out, 'w', encoding="utf8", newline="\n")
         out.write('\n'.join(self.output))
         out.close()
         


### PR DESCRIPTION
If this tool is used in Windows, it will generate dos-styled newlines (\r\n) instead of unix-styled newlines (\n).  This would cause unwanted whole-file changeset after using CleanJSON.py to reformat.

This commit tries to fix this issue.