### PR TITLE
zh-cn: Sync to the latest English version

### DIFF
--- a/zh-cn.json
+++ b/zh-cn.json
@@ -3648,6 +3648,8 @@
         "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.MuteBadge.Content": "授予/移除静音状态徽章",
         "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PotatoBadge": "低配设备徽章",
         "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PotatoBadge.Content": "授予/移除低配设备徽章（向他人表明你需要优化场景）",
+        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges": "彩虹旗徽章",
+        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges.Content": "授予/移除彩虹旗徽章（无参数时列出所有可用徽章）",
 
         "Help.LinksAndResources.PlatformBotCommands.BenefitCommands.GetHeadlessAccessCode": "获取云端客户端访问码",
         "Help.LinksAndResources.PlatformBotCommands.BenefitCommands.GetHeadlessAccessCode.Content": "获取云端客户端测试分支访问码（需订阅者特权）",
@@ -3705,6 +3707,9 @@
         "Help.LinksAndResources.PlatformBotCommands.MiscCommands.GetGitHubIssue.Command": "/GetIssue <问题编号>",
         "Help.LinksAndResources.PlatformBotCommands.MiscCommands.Echo.Command": "/Echo <消息>",
 
+        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges.Command": "/AddPrideBadge <彩虹旗名称><color=#ff0000>（谨慎标记，内含同性恋元素）</color>",
+        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges.SecondaryCommand": "/RemovePrideBadge <彩虹旗名称><color=#ff0000>（谨慎标记，内含同性恋元素）</color>",
+
         "Help.LinksAndResources.PlatformBotCommands.BenefitCommands.SharedStorage.Command": "/ShareStorageWithUser <玩家名> <存储量>",
         "Help.LinksAndResources.PlatformBotCommands.BenefitCommands.SharedStorage.SecondaryCommand": "/ShareStorageWithGroup <群组名> <存储量>",
         "Help.LinksAndResources.PlatformBotCommands.BenefitCommands.SetCustom2DBadge.Command": "/Set2DBadge <资源哈希>",
@@ -3735,6 +3740,7 @@
         "Help.TeamTitle.Support": "技术支持",
         "Help.TeamTitle.UI": "玩家界面",
         "Help.TeamTitle.VideoProducer": "视频制作",
+        "Help.TeamTitle.HeadOfTrustAndSafety": "安全与守护负责人",
 
         "Help.About.Badges": "徽章系统",
 

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -3707,8 +3707,8 @@
         "Help.LinksAndResources.PlatformBotCommands.MiscCommands.GetGitHubIssue.Command": "/GetIssue <问题编号>",
         "Help.LinksAndResources.PlatformBotCommands.MiscCommands.Echo.Command": "/Echo <消息>",
 
-        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges.Command": "/AddPrideBadge <彩虹旗名称><color=#ff0000>（谨慎标记，内含同性恋元素）</color>",
-        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges.SecondaryCommand": "/RemovePrideBadge <彩虹旗名称><color=#ff0000>（谨慎标记，内含同性恋元素）</color>",
+        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges.Command": "/AddPrideBadge <彩虹旗名称>",
+        "Help.LinksAndResources.PlatformBotCommands.BadgeCommands.PrideFlagBadges.SecondaryCommand": "/RemovePrideBadge <彩虹旗名称>",
 
         "Help.LinksAndResources.PlatformBotCommands.BenefitCommands.SharedStorage.Command": "/ShareStorageWithUser <玩家名> <存储量>",
         "Help.LinksAndResources.PlatformBotCommands.BenefitCommands.SharedStorage.SecondaryCommand": "/ShareStorageWithGroup <群组名> <存储量>",


### PR DESCRIPTION
We have a.... different style of thought. In most of times the translation must follow our language habit.
And now I checked. I think it's fine now.
I think that's all. The translation are now back to standard protocal. But it will need to polish it. Depending on my team's suggestions.