### PR TITLE
Improve German Translation

### DIFF
--- a/de.json
+++ b/de.json
@@ -123,7 +123,7 @@
         "Inventory.Delete": "Löschen",
         "Inventory.CreateDirectory": "Neuer Ordner",
         "Inventory.SaveHeld": "Gehaltenes Objekt speichern",
-        "Inventory.GetURL": "URL holen",
+        "Inventory.GetURL": "URL kopieren",
         "Inventory.Inventories": "Inventare",
         "Inventory.Share": "Veröffentlichen",
         "Inventory.Unshare": "Veröffentlichung beenden",
@@ -846,7 +846,7 @@
         "Tools.ProtoFlux.NodeBrowser": "Nodebrowser",
         "Tools.ProtoFlux.PackInPlace": "Hier verpacken",
         "Tools.ProtoFlux.PackInto": "Verpacken nach <size=50%>{name}</size>",
-        "Tools.ProtoFlux.Unpack": "Entpacke <size=50%>{name}</size>",
+        "Tools.ProtoFlux.Unpack": "Entpacken aus <size=50%>{name}</size>",
         "Tools.ProtoFlux.ExplicitCast": "Explizite Umwandlung\n<size=50%>(<color=red>Warnung:</color> Möglicher Informationsverlust)</size>",
 
         "Tools.Meter.Mode.Ray": "Modus: Projiziert",
@@ -896,7 +896,7 @@
         "CreateNew.LegacyParticleSystem": "Altes Partikelsystem",
 
         "CreateNew.Object": "Objekt",
-        "CreateNew.Object.AvatarCreator": "Avatar-Assistent",
+        "CreateNew.Object.AvatarCreator": "Avatar-Ersteller",
         "CreateNew.Object.Camera": "Kamera",
         "CreateNew.Object.ReflectionProbe": "Reflexionssonde",
         "CreateNew.Object.ReverbZone": "Hallzone",
@@ -2052,7 +2052,7 @@
         "Settings.ResolutionSettings.ApplyResolution": "Änderungen übernehmen",
 
         "Settings.RenderingQualitySettings": "Rendering-Qualität",
-        "Settings.RenderingQualitySettings.PerPixelLights": "Per-Pixel-Lichter",
+        "Settings.RenderingQualitySettings.PerPixelLights": "Pro-Pixel-Lichter",
         "Settings.RenderingQualitySettings.PerPixelLights.Description": "Dies steuert, wie viele Punkt- und Spotlichter direkt auf Objekte angewandt werden können, die mit der Vorwärtsmethode wiedergegeben werden - typischerweise transparente und Nicht-PBS-Objekte (z. B. mit dem Toon-Shader).\n\nEine Erhöhung dieses Wertes verbessert die Qualität der Beleuchtung und reduziert das Farbflimmern bei mehreren Lichtern auf Kosten der Geschwindigkeit - das Objekt muss für jedes Licht, das es beeinflusst, gerendert werden.",
         "Settings.RenderingQualitySettings.ShadowCascades": "Schatten-Kaskaden",
         "Settings.RenderingQualitySettings.ShadowCascades.Description": "Diese Einstellung steuert die Kaskadierung der Auflösung der Schatten für gerichtete Lichter in der Welt. Kaskaden verteilen die Auflösung der Schatten-Map besser - sie bieten eine höhere Schattenauflösung in der Nähe und eine geringere Auflösung in der Ferne, kosten aber mehr Leistung beim Rendern.",
@@ -3190,12 +3190,12 @@
         "Help.PlatformEssentialsSubmissionLinkName": "{appName} Essentials Einreichungsformular",
 
         "Help.Modal.Header": "Wobei brauchen Sie Hilfe?",
-        "Help.Modal.Avatar": "Ich will meinen Avatar einrichten...",
+        "Help.Modal.Avatar": "Ich möchte einen Avatar einrichten...",
         "Help.Modal.Explore": "Ich möchte Welten erkunden...",
         "Help.Modal.Graphics": "Wie stelle ich meine Grafik ein?",
         "Help.Modal.Socialize": "Ich möchte Kontakte knüpfen...",
         "Help.Modal.Building": "Ich möchte gestalten...",
-        "Help.Modal.BrowseTopics": "Ich will selbst in der Hilfe stöbern",
+        "Help.Modal.BrowseTopics": "Ich möchte selbst in der Hilfe stöbern",
 
         "Help.ControllerDiagram.ViewingYourControllerLayout": "Ihr Controller-Layout anzeigen",
         "Help.ControllerDiagram.GoToYourControllerLayout": "Zu Ihrem Controller-Layout gehen",


### PR DESCRIPTION
Just some minor improvements to the German locale.

Reasonings:
`URL holen` => `URL kopieren`
While "URL holen" is a more direct translation of "Get URL", to me, "holen" has this connotation of physically going somewhere to get something and then bringing it back to where you are. Which doesn't make sense here, since the URL is right there, you don't need to get it from somewhere else. So the new one means "Copy URL", which is what the button does.

`Entpacke <size=50%>{name}</size>` => `Entpacken aus <size=50%>{name}</size>`
This one's for consistency with "Verpacken", as well as not having a button be in the imperative. (rather, it is in the infinitive now, like the other one, which is more natural for buttons)

`Avatar-Assistent` => `Avatar-Ersteller`
"Assistent" is the German translation for software wizards. The avatar creator is not an avatar wizard.

`Per-Pixel-Lichter` => `Pro-Pixel-Lichter`
"Per-XYZ" isn't a thing in German. (or rather, it means "via XYZ" instead)

The `will` => `möchte` changes:
Both of these mean "want", though "möchte" is more polite and less demanding. The latter is more appropriate here and most of the other "I want to XYZ" lines of the help tab were already using it.
Since "I want to set up my avatar..." ("Ich möchte meinen Avatar einrichten...") would be too long for the button with this change, it's now "I want to set up an avatar" ("Ich möchte einen Avatar einrichten..."), which barely fits. And I hope that's alright.