### PR TITLE
Add "(Sun)" to directional light's name

### DIFF
--- a/en.json
+++ b/en.json
@@ -948,7 +948,7 @@
         "CreateNew.Light": "Light",
         "CreateNew.Light.Point": "Point",
         "CreateNew.Light.Spot": "Spot",
-        "CreateNew.Light.Directional": "Directional",
+        "CreateNew.Light.Directional": "Directional (Sun)",
 
         "CreateNew.Materials": "Materials",
 


### PR DESCRIPTION
This was already a thing in the German translation and I thought, instead of making that one worse for accuracy, I'd improve the English one instead.