### PR TITLE
Create missing TooManyRegistrations.Description key

### DIFF
--- a/en.json
+++ b/en.json
@@ -1,6 +1,6 @@
 {
     "localeCode": "en",
-    "authors": ["Frooxius", "Enverex", "rampa_3", "Melnus", "dfgHiatus", "Earthmark", "Ryuvi", "Nammi", "WattleFoxxo", "StiefelJackal", "RueShejn", "NepuShiro", "Choco", "Modern", "Xau", "Charizmare", "bredo"],
+    "authors": ["Frooxius", "Enverex", "rampa_3", "Melnus", "dfgHiatus", "Earthmark", "Ryuvi", "Nammi", "WattleFoxxo", "StiefelJackal", "RueShejn", "NepuShiro", "Choco", "Modern", "Xau", "Charizmare", "bredo", "Marshall_vak"],
     "messages": {
 
         "General.OK": "OK",
@@ -521,6 +521,9 @@
 
         "Register.UnknownError": "Unknown Error",
         "Register.UnknownError.Description": "An unknown error occurred during registration. Please contact support at {supportUrl}.",
+
+        "TooManyRegistrations": "Too Many Registrations",
+        "TooManyRegistrations.Description": "Too many registration attempts. Please try again later or contact support at {supportUrl}.",
 
         "Account.Login": "Login",
         "Account.Logout": "Logout",


### PR DESCRIPTION
Create locale keys for ``TooManyRegistrations`` and ``TooManyRegistrations.Description`` #863

These missing keys have been around for a bit, and another user has run into this in the mentor discord.