### PR TITLE
tweak(en): replace Resonite with {appName}

### DIFF
--- a/en.json
+++ b/en.json
@@ -1655,7 +1655,7 @@
         "Settings.AudioOutputDeviceSettings.DevicePriorities.Breadcrumb": "Audio Output Devices",
         "Settings.AudioOutputDeviceSettings.SetAsDefault": "Set As Default",
         "Settings.AudioOutputDeviceSettings.ForceRefreshDevices": "Force Refresh Audio Devices",
-        "Settings.AudioOutputDeviceSettings.ForceRefreshDevices.Description": "Pressing this will force {appName} to refresh the audio device list. In most cases this should not be needed, but if {appName} is failing to pick up audio device that was added, using this might help.",
+        "Settings.AudioOutputDeviceSettings.ForceRefreshDevices.Description": "Pressing this will force {appName} to refresh the audio device list. New audio devices are usually found; however, if {appName} fails to pick up an added audio device, pressing this might help.",
         "Settings.AudioOutputDeviceSettings.SeparateStreamingCameraOutput": "Separate Streaming Camera Output",
         "Settings.AudioOutputDeviceSettings.SeparateStreamingCameraOutput.Description": "When enabled, the streaming camera will render audio from its viewpoint and output it to a separate audio device.<br><br>This lets you keep your own audio from your perspective, while also capturing audio from the camera's perspective.<br><br>For this to work, the selected device must be different from your normal output device.",
         "Settings.AudioOutputDeviceSettings.StreamingCameraPriorities": "Streaming Camera Output Devices",


### PR DESCRIPTION
This PR updates `Settings.AudioOutputDeviceSettings.ForceRefreshDevices.Description` and `Tutorial.HelpTabPanel.Content` to use `{appName}` instead of Resonite. The PR also slightly updates the last sentence of `Settings.AudioOutputDeviceSettings.ForceRefreshDevices.Description` to sound slightly better.

Resolves #889