### PR TITLE
fix ja SAPの翻訳が挙動と異なるのを修正

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -1,6 +1,6 @@
 {
     "localeCode": "ja",
-    "authors": ["orange", "Melnus", "Aesc", "kazu", "Rabbuttz", "zozokasu", "rhenium", "chaba_take", "hantabaru1014", "ginjake"],
+    "authors": ["orange", "Melnus", "Aesc", "kazu", "Rabbuttz", "zozokasu", "rhenium", "chaba_take", "hantabaru1014", "ginjake", "MarkN"],
     "messages": {
 
         "General.OK": "OK",


### PR DESCRIPTION
SimpleAvatarProtectionの削除ボタンの翻訳が実際の挙動と異なっていたので、原文に近い形に修正