### PR TITLE
ja: fix avatar protection unavailable

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -988,7 +988,7 @@
         "AvatarCreator.TryAlignHands": "手の位置をあわせる",
         "AvatarCreator.AlignToolAnchors": "ツールアンカーの位置を揃える",
         "AvatarCreator.Create": "作成",
-        "AvatarCreator.ProtectionUnavailable": "<i>このワールド(local home)ではアバター保護をつけることが。別のワールドに切り替えてから、アバターを作成してください。</i>",
+        "AvatarCreator.ProtectionUnavailable": "<i>このワールドではアバター保護をつけることができません。<br>別のワールドに切り替えてから、アバターを作成してください。</i>",
 
         "Importer.General.AsRawFile": "ファイル​​アイテム",
 


### PR DESCRIPTION
Fix broken words and incorrect line breaks.
言葉が途切れていたり、改行がおかしいのを修正

このワールド(local home)ではアバター保護をつけることが。別のワールドに～

to

このワールドではアバター保護をつけることができません。<br>別のワールドに～