### PR TITLE
ja: fix description for SkinWeightMode

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -2080,7 +2080,7 @@
         "Settings.RenderingQualitySettings.ShadowDistance": "影の距離",
         "Settings.RenderingQualitySettings.ShadowDistance.Description": "影がカバーする距離を設定できます。この値を大きくすると、より遠くの部分が影で適切にカバーされるようになりますが、影の影響がより広い範囲に広がります。\n\nこの設定は、シャドウカスケードや解像度と一緒に変更する必要があります。- 影の解像度を高くすると、距離を長くすることができます。影の解像度とカスケードを下げると距離が短くなり，影がより鮮明になります。",
         "Settings.RenderingQualitySettings.SkinWeightMode": "スキンウェイト",
-        "Settings.RenderingQualitySettings.SkinWeightMode.Description": "スキニングされたメッシュ（アバターのようにボーンによって変形する3Dモデル）で、各頂点の位置に影響を与えるために使用されるボーン数を制御します。\n\nこの値を下げると、パフォーマンスは多少下がりますが、変形の質は低下し、曲がりが粗くなり、他の歪みが発生します。",
+        "Settings.RenderingQualitySettings.SkinWeightMode.Description": "スキニングされたメッシュ（アバターのようにボーンによって変形する3Dモデル）で、各頂点の位置に影響を与えるために使用されるボーン数を制御します。\n\nこの値を下げると、パフォーマンスが多少向上しますが、変形の質は低下し、曲がりが粗くなり、他の歪みが発生します。",
 
         "Settings.RendererDecouplingSettings": "レンダラー分離",
         "Settings.RendererDecouplingSettings.ActivationFramerate": "有効化フレームレート",


### PR DESCRIPTION
Description The current Japanese translation for "save some performance" was "パフォーマンスは多少下がります" (performance will decrease slightly), which is the opposite of the original meaning. I have corrected it to "向上します" (will improve) to accurately reflect that lowering the value reduces processing load.

Changes

Before: この値を下げると、パフォーマンスは多少下がりますが、

After: この値を下げると、パフォーマンスが多少向上しますが、