### PR TITLE
tweak(en): create smoother promo code descriptions

### DIFF
--- a/en.json
+++ b/en.json
@@ -529,10 +529,10 @@
         "Register.InvalidPassword.Description": "Your password is invalid. It must contain at least 8 characters, including 1 digit, 1 uppercase letter and 1 lowercase letter.",
 
         "Register.InvalidPromoCode": "Invalid Promo Code",
-        "Register.InvalidPromoCode.Description": "The Promo Code you used is not valid! Check if it's spelled correctly. Case does not matter.",
+        "Register.InvalidPromoCode.Description": "The promo code entered is invalid. Please verify the spelling and try again. It isn't case-sensitive.",
 
         "Register.ExpiredPromoCode": "Expired Promo Code",
-        "Register.ExpiredPromoCode.Description": "Unfortunately this Promo Code is not active anymore. You can try using a different one or remove it.",
+        "Register.ExpiredPromoCode.Description": "The promo code entered has expired. Please try a different one or remove it.",
 
         "Register.EmailAlreadyRegistered": "Email already registered",
         "Register.EmailAlreadyRegistered.Description": "An account using this email already exists, if you've forgotten your password you can click \"Lost Password\". Or you can contact support at {supportUrl}.",


### PR DESCRIPTION
Promo code descriptions have been tweaked to sound slightly smoother. This also avoids having a separate `Register.InvalidPromoCode.Description` key for `en-gb` since it is common to use "spelt" instead of "spelled" for British English.