### PR TITLE
en: Fix typo in Always Hide Gizmos

### DIFF
--- a/en.json
+++ b/en.json
@@ -1982,7 +1982,7 @@
         "Settings.PhotoCaptureSettings.AlwaysHideNameplates": "Always Hide Nameplates",
         "Settings.PhotoCaptureSettings.AlwaysHideNameplates.Description": "Turn this on if you want nameplates to never show in your photos. This setting is independent of the current nameplate visibility and will always ensure that they are hidden in captured photos.",
         "Settings.PhotoCaptureSettings.AlwaysHideGizmos": "Always Hide Gizmos",
-        "Settings.PhotoCaptureSettings.AlwaysHideGizmos.Description": "Turn this on if you want to hide any developer gizmos in your photos. This can help in cases where you want to take clean photos even in case someone is editing something. Inspectors and ProfoFlux will remain visible.",
+        "Settings.PhotoCaptureSettings.AlwaysHideGizmos.Description": "Turn this on if you want to hide any developer gizmos in your photos. This can help in cases where you want to take clean photos even in case someone is editing something. Inspectors and ProtoFlux will remain visible.",
 
         "Settings.DesktopRenderSettings.FieldOfView": "Field of view",
         "Settings.DesktopRenderSettings.FieldOfView.Description": "Use this to control the field of view (FOV) when in desktop mode. Larger values will give you wider view at the cost of greater distortion on the sides.",


### PR DESCRIPTION
Fixes a typo in Settings.PhotoCaptureSettings.AlwaysHideGizmos.Description (ProfoFlux -> ProtoFlux)