### PR TITLE
en: Fix description typo in Help.LinksAndResources

### DIFF
--- a/en.json
+++ b/en.json
@@ -3746,7 +3746,7 @@
         "Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariableType": "Set Cloud Variable Type",
         "Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariableType.Content": "Sets the type for a user or group cloud variable.",
         "Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariableDefaultValue": "Set Cloud Variable Default Value",
-        "Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariableDefaultValue.Content": "Sets the type for a user or group cloud variable.",
+        "Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariableDefaultValue.Content": "Sets the default value for a user or group cloud variable.",
         "Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariablePermissions": "Set Cloud Variable Permissions",
         "Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariablePermissions.Content": "Sets the permissions for a user or group cloud variable.",
 


### PR DESCRIPTION
Just a simple fix of small mistake in `Help.LinksAndResources.PlatformBotCommands.CloudVariables.SetCloudVariableDefaultValue.Content`

Closes: #1000 