### PR TITLE
zh-cn:Sync to the latest English version

### DIFF
--- a/zh-cn.json
+++ b/zh-cn.json
@@ -383,7 +383,7 @@
         "Tools.CreateNewWorld": "创建新世界",
         "Tools.Debug": "调试",
         "Tools.StreamAudio": "流音频",
-        "Tools.StreamVideo": "串流自定义视频<sup><color=hero.red>测试版",
+        "Tools.StreamVideo": "串流自定义视频<sup><color=hero.red>（测试版）",
         "Tools.StreamVideo.Stop": "停止串流自定义视频",
         "Tools.Setup2FA": "设置双重认证",
 
@@ -1811,7 +1811,7 @@
         "Settings.DebugSettings.ConvertParticleSystems": "转换粒子系统到 PhotonDust",
         "Settings.DebugSettings.ConvertParticleSystems.Description": "启用此选项将为任何 <b>新</b> 加载的物品和世界从旧式粒子系统转换到新的自定义粒子系统（ PhotonDust ）。<br><br><color=red>这仅用于测试目的！</color> 如果您不是测试人员, 我们不建议打开这个选项, 您的内容有可能会因此导致损坏。<br><br>如果您想帮助测试, 请查看我们的 GitHub/Discord 。",
         "Settings.DebugSettings.ShowMediaMTXWindow": "显示 MediaMTX 窗口",
-        "Settings.DebugSettings.ShowMediaMTXWindow.Description": "串流画面时, MediaMTX 实例会显示一个可见窗口，便于查看其输出内容。<br><br><color=hero.red>警告:</color> 如果手动关闭该窗口, 流媒体功能将无法正常使用。",
+        "Settings.DebugSettings.ShowMediaMTXWindow.Description": "串流画面时, MediaMTX 实例会显示一个可见窗口。 这有助于查看其输出内容。<br><br><color=hero.red>警告:</color> 如果手动关闭该窗口, 流媒体功能将无法正常使用。",
         "Settings.DebugSettings.UseProtonForMediaMTX": "为 MediaMTX 使用 Proton",
         "Settings.DebugSettings.UseProtonForMediaMTX.Description": "在 Linux 系统上, 在 Proton 兼容层下启动 Windows 版本的 MediaMTX, 而不是启动 Linux 原生版本。",
         "Settings.DebugSettings.ForceSoftwareVideoEncoder": "强制使用软件视频编码器",

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1812,7 +1812,7 @@
         "Settings.DebugSettings.ConvertParticleSystems.Description": "启用此选项将为任何 <b>新</b> 加载的物品和世界从旧式粒子系统转换到新的自定义粒子系统（ PhotonDust ）。<br><br><color=red>这仅用于测试目的！</color> 如果您不是测试人员, 我们不建议打开这个选项, 您的内容有可能会因此导致损坏。<br><br>如果您想帮助测试, 请查看我们的 GitHub/Discord 。",
         "Settings.DebugSettings.ShowMediaMTXWindow": "显示 MediaMTX 窗口",
         "Settings.DebugSettings.ShowMediaMTXWindow.Description": "串流画面时, MediaMTX 实例会显示一个可见窗口。 这有助于查看其输出内容。<br><br><color=hero.red>警告:</color> 如果手动关闭该窗口, 流媒体功能将无法正常使用。",
-        "Settings.DebugSettings.UseProtonForMediaMTX": "为 MediaMTX 使用 Proton",
+        "Settings.DebugSettings.UseProtonForMediaMTX": "使用 Proton 运行 MediaMTX",
         "Settings.DebugSettings.UseProtonForMediaMTX.Description": "在 Linux 系统上, 不启动 MediaMTX 的 Linux 原生版本, 而是在 Proton 下启动 Windows 版本。",
         "Settings.DebugSettings.ForceSoftwareVideoEncoder": "强制使用软件视频编码器",
         "Settings.DebugSettings.ForceSoftwareVideoEncoder.Description": "推流/串流桌面时使用软件视频编码器, 而非硬件视频编码。",

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1813,7 +1813,7 @@
         "Settings.DebugSettings.ShowMediaMTXWindow": "显示 MediaMTX 窗口",
         "Settings.DebugSettings.ShowMediaMTXWindow.Description": "串流画面时, MediaMTX 实例会显示一个可见窗口。 这有助于查看其输出内容。<br><br><color=hero.red>警告:</color> 如果手动关闭该窗口, 流媒体功能将无法正常使用。",
         "Settings.DebugSettings.UseProtonForMediaMTX": "为 MediaMTX 使用 Proton",
-        "Settings.DebugSettings.UseProtonForMediaMTX.Description": "在 Linux 系统上, 在 Proton 兼容层下启动 Windows 版本的 MediaMTX, 而不是启动 Linux 原生版本。",
+        "Settings.DebugSettings.UseProtonForMediaMTX.Description": "在 Linux 系统上, 不启动 MediaMTX 的 Linux 原生版本, 而是在 Proton 下启动 Windows 版本。",
         "Settings.DebugSettings.ForceSoftwareVideoEncoder": "强制使用软件视频编码器",
         "Settings.DebugSettings.ForceSoftwareVideoEncoder.Description": "推流/串流桌面时使用软件视频编码器, 而非硬件视频编码。",
 

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -383,7 +383,7 @@
         "Tools.CreateNewWorld": "创建新世界",
         "Tools.Debug": "调试",
         "Tools.StreamAudio": "流音频",
-        "Tools.StreamVideo": "串流自定义视频<sup><color=hero.red>（测试版）",
+        "Tools.StreamVideo": "串流自定义视频<sup><color=hero.red>测试版",
         "Tools.StreamVideo.Stop": "停止串流自定义视频",
         "Tools.Setup2FA": "设置双重认证",
 

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1811,7 +1811,7 @@
         "Settings.DebugSettings.ConvertParticleSystems": "转换粒子系统到 PhotonDust",
         "Settings.DebugSettings.ConvertParticleSystems.Description": "启用此选项将为任何 <b>新</b> 加载的物品和世界从旧式粒子系统转换到新的自定义粒子系统（ PhotonDust ）。<br><br><color=red>这仅用于测试目的！</color> 如果您不是测试人员, 我们不建议打开这个选项, 您的内容有可能会因此导致损坏。<br><br>如果您想帮助测试, 请查看我们的 GitHub/Discord 。",
         "Settings.DebugSettings.ShowMediaMTXWindow": "显示 MediaMTX 窗口",
-        "Settings.DebugSettings.ShowMediaMTXWindow.Description": "串流画面时, MediaMTX 实例会显示一个可见窗口。 这有助于查看其输出内容。<br><br><color=hero.red>警告:</color> 如果手动关闭该窗口, 流媒体功能将无法正常使用。",
+        "Settings.DebugSettings.ShowMediaMTXWindow.Description": "在串流画面时, MediaMTX 实例会显示一个可见窗口。 这有助于查看其输出内容。<br><br><color=hero.red>警告:</color> 如果手动关闭该窗口, 流媒体传输功能将会中断。",
         "Settings.DebugSettings.UseProtonForMediaMTX": "使用 Proton 运行 MediaMTX",
         "Settings.DebugSettings.UseProtonForMediaMTX.Description": "在 Linux 系统上, 不启动 MediaMTX 的 Linux 原生版本, 而是在 Proton 下启动 Windows 版本。",
         "Settings.DebugSettings.ForceSoftwareVideoEncoder": "强制使用软件视频编码器",

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1775,7 +1775,7 @@
         "Settings.RealtimeNetworkingSettings.PreferTCP": "尽可能使用 TCP",
         "Settings.RealtimeNetworkingSettings.PreferTCP.Description": "启用后, TCP 连接将优先于所有其他协议。这主要影响局域网中的连接, 因为互联网上的连接默认不使用 TCP 。<br><br>TCP 在局域网中性能更优, 并且能在某些基于 UDP 协议无法工作的网络环境中正常运行。<br><br>不过, TCP 也可能受到\"队头阻塞\"（ Head-of-Line Blocking ）的影响, 导致语音和姿态数据明显延迟。",
         "Settings.RealtimeNetworkingSettings.PreferQUIC": "尽可能使用 QUIC (实验性功能)",
-        "Settings.RealtimeNetworkingSettings.PreferQUIC.Description": "启用后, QUIC连接将优于其他协议 (TCP 除外) 。\n\n该协议的支持目前尚不完整且处于实验阶段, 但性能可能优于默认的LNL协议。\n\n服务器必须明确配置为可通过 QUIC 访问, 才能实现此功能。",
+        "Settings.RealtimeNetworkingSettings.PreferQUIC.Description": "启用后, QUIC连接将优于其他协议 (TCP 除外) 。\n\n该协议的支持目前尚不完整且处于实验阶段, 但性能可能优于默认的LNL协议。\n\n服务器必须明确配置为可通过 QUIC 访问, 此功能才可生效。",
         "Settings.RealtimeNetworkingSettings.LNL_WindowSize": "LNL 数据包大小",
         "Settings.RealtimeNetworkingSettings.LNL_WindowSize.Description": "该值会控制用于实时联网的 LNL 协议的数据包大小。 更改此设置将对您加入的所有房间立即生效。<br><br>如果您遇到数据包排队的情况, 可以增加该值, 这样可以提高连接吞吐量。不过, 数值越大也会使连接越不稳定, 所以要谨慎。<br><br><color=hero.yellow>默认值: </color> 64<br><br><color=hero.red>重要说明: </color> 此设置仅用于诊断和临时性解决, 将来会自动调整此值。",
 

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -328,10 +328,10 @@
 
         "World.AccessLevel.Anyone": "公开",
         "World.AccessLevel.RegisteredUsers": "已注册用户",
-        "World.AccessLevel.Contacts": "仅好友",
+        "World.AccessLevel.Contacts": "仅限好友",
         "World.AccessLevel.ContactsPlus": "好友+",
         "World.AccessLevel.LAN": "局域网",
-        "World.AccessLevel.Private": "仅邀请",
+        "World.AccessLevel.Private": "仅限邀请",
 
         "World.SortParameter.SearchScore": "搜索分数",
         "World.SortParameter.Name": "名称",
@@ -383,7 +383,8 @@
         "Tools.CreateNewWorld": "创建新世界",
         "Tools.Debug": "调试",
         "Tools.StreamAudio": "流音频",
-        "Tools.StreamVideo": "串流自定义视频",
+        "Tools.StreamVideo": "串流自定义视频<sup><color=hero.red>测试版",
+        "Tools.StreamVideo.Stop": "停止串流自定义视频",
         "Tools.Setup2FA": "设置双重认证",
 
         "Tools.StreamAudio.Dialog.Title": "创建音频流",
@@ -1774,7 +1775,7 @@
         "Settings.RealtimeNetworkingSettings.PreferTCP": "尽可能使用 TCP",
         "Settings.RealtimeNetworkingSettings.PreferTCP.Description": "启用后, TCP 连接将优先于所有其他协议。这主要影响局域网中的连接, 因为互联网上的连接默认不使用 TCP 。<br><br>TCP 在局域网中性能更优, 并且能在某些基于 UDP 协议无法工作的网络环境中正常运行。<br><br>不过, TCP 也可能受到\"队头阻塞\"（ Head-of-Line Blocking ）的影响, 导致语音和姿态数据明显延迟。",
         "Settings.RealtimeNetworkingSettings.PreferQUIC": "尽可能使用 QUIC (实验性功能)",
-        "Settings.RealtimeNetworkingSettings.PreferQUIC.Description": "启用后, QUIC连接将优于其他协议 (TCP 除外) 。\n\n该协议的支持目前尚不完整且处于实验阶段, 但性能可能优于默认的LNL协议。\n\n服务器必须明确配置为可通过 QUIC 访问, 此功能才可生效。",
+        "Settings.RealtimeNetworkingSettings.PreferQUIC.Description": "启用后, QUIC连接将优于其他协议 (TCP 除外) 。\n\n该协议的支持目前尚不完整且处于实验阶段, 但性能可能优于默认的LNL协议。\n\n服务器必须明确配置为可通过 QUIC 访问, 才能实现此功能。",
         "Settings.RealtimeNetworkingSettings.LNL_WindowSize": "LNL 数据包大小",
         "Settings.RealtimeNetworkingSettings.LNL_WindowSize.Description": "该值会控制用于实时联网的 LNL 协议的数据包大小。 更改此设置将对您加入的所有房间立即生效。<br><br>如果您遇到数据包排队的情况, 可以增加该值, 这样可以提高连接吞吐量。不过, 数值越大也会使连接越不稳定, 所以要谨慎。<br><br><color=hero.yellow>默认值: </color> 64<br><br><color=hero.red>重要说明: </color> 此设置仅用于诊断和临时性解决, 将来会自动调整此值。",
 
@@ -1809,6 +1810,12 @@
         "Settings.DebugSettings.DebugInputBindings.Description": "启用后, 您将看到输入绑定系统的调试信息。 这对开发人员非常有用。",
         "Settings.DebugSettings.ConvertParticleSystems": "转换粒子系统到 PhotonDust",
         "Settings.DebugSettings.ConvertParticleSystems.Description": "启用此选项将为任何 <b>新</b> 加载的物品和世界从旧式粒子系统转换到新的自定义粒子系统（ PhotonDust ）。<br><br><color=red>这仅用于测试目的！</color> 如果您不是测试人员, 我们不建议打开这个选项, 您的内容有可能会因此导致损坏。<br><br>如果您想帮助测试, 请查看我们的 GitHub/Discord 。",
+        "Settings.DebugSettings.ShowMediaMTXWindow": "显示 MediaMTX 窗口",
+        "Settings.DebugSettings.ShowMediaMTXWindow.Description": "串流画面时, MediaMTX 实例会显示一个可见窗口，便于查看其输出内容。<br><br><color=hero.red>警告:</color> 如果手动关闭该窗口, 流媒体功能将无法正常使用。",
+        "Settings.DebugSettings.UseProtonForMediaMTX": "为 MediaMTX 使用 Proton",
+        "Settings.DebugSettings.UseProtonForMediaMTX.Description": "在 Linux 系统上, 在 Proton 兼容层下启动 Windows 版本的 MediaMTX, 而不是启动 Linux 原生版本。",
+        "Settings.DebugSettings.ForceSoftwareVideoEncoder": "强制使用软件视频编码器",
+        "Settings.DebugSettings.ForceSoftwareVideoEncoder.Description": "推流/串流桌面时使用软件视频编码器, 而非硬件视频编码。",
 
         "Settings.LegacyFeatureSettings.UseLegacyGripEquip": "双击手柄握把键装备物品",
         "Settings.LegacyFeatureSettings.UseLegacyGripEquip.Description": "启用后, 只要连续按两次握把键, 就可以装备工具和小物件。这一设置可能会在某个时候被移除。",
@@ -2617,6 +2624,7 @@
         "Desktop.Opacity": "不透明度: {n,number,percent}",
 
         "Desktop.Stream": "屏幕分享",
+        "Desktop.StopStream": "停止屏幕分享",
         "Desktop.Stream.Display": "显示器 {index}: {width}x{height}",
         "Desktop.Stream.Title": "配置屏幕分享",
         "Desktop.Stream.Audio": "包含桌面音频",


### PR DESCRIPTION
It is done and ready. As usual, appeal to local players' talking style. That is localization.
<img width="252" height="252" alt="87CB6AF8CEF57CE96331AAAB1FDB8249" src="https://github.com/user-attachments/assets/1a9aa2dc-8cd6-457d-89ff-4e0a518c2549" />

对于翻译人员的话语：
本次翻译中改变了对于Contacts中从仅变为仅限，这个考量是考虑到强调的意味，告诉要调整房间进入权限的房主强调选择这个意味着只有房主的好友可以进入，或者只能你邀请他，他才能进来。
至于MediaMTX的话，暂时通过语感没看出比较拗口的地方，倒是提一下这里Settings.DebugSettings.ShowMediaMTXWindow.Description
原文中说的是When streaming videos，本意就是在你把画面实时串流给其他人的时候，而在这里videos虽然是叫做视频，但串流的内容范围比较大，且考虑到没有什么人会去真的说我要串流视频什么的（appeal to local players' talking style），所以翻译为串流**画面**时比较合适。