### PR TITLE
zh-cn:Sync to the latest English version

### DIFF
--- a/zh-cn.json
+++ b/zh-cn.json
@@ -2070,6 +2070,8 @@
         "Settings.VideoStreamingServicesSettings": "视频流服务设置",
         "Settings.VideoStreamingServicesSettings.UseCookiesFromBrowser": "从浏览器中使用 Cookie",
         "Settings.VideoStreamingServicesSettings.UseCookiesFromBrowser.Description": "如果您无法加载 YouTube 和其他服务的视频, 请选择您通常用于加载 Cookie 的浏览器。这会增加视频成功加载的几率。",
+        "Settings.VideoStreamingServicesSettings.PreferredResolution": "首选清晰度",
+        "Settings.VideoStreamingServicesSettings.PreferredResolution.Description": "视频流媒体服务在默认情况下应加载的理想清晰度（除非在具体播放器中单独重置/覆盖）。 <br><br>提高此设置会提高视频画质，但也会增加网络带宽和 CPU 消耗。 <br><br>如果遇到视频卡顿问题，您可以尝试降低该数值。",
 
         "Settings.PostProcessingSettings": "后期处理",
         "Settings.PostProcessingSettings.MotionBlurIntensity": "动态模糊强度",

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -2071,7 +2071,7 @@
         "Settings.VideoStreamingServicesSettings.UseCookiesFromBrowser": "从浏览器中使用 Cookie",
         "Settings.VideoStreamingServicesSettings.UseCookiesFromBrowser.Description": "如果您无法加载 YouTube 和其他服务的视频, 请选择您通常用于加载 Cookie 的浏览器。这会增加视频成功加载的几率。",
         "Settings.VideoStreamingServicesSettings.PreferredResolution": "首选清晰度",
-        "Settings.VideoStreamingServicesSettings.PreferredResolution.Description": "视频流媒体服务在默认情况下应加载的理想清晰度（除非在具体播放器中单独重置/覆盖）。 <br><br>提高此设置会提高视频画质，但也会增加网络带宽和 CPU 消耗。 <br><br>如果遇到视频卡顿问题，您可以尝试降低该数值。",
+        "Settings.VideoStreamingServicesSettings.PreferredResolution.Description": "视频流媒体服务在默认情况下应加载的理想清晰度 (除非在特定播放器中另行覆盖)。 <br><br>提高此数值会提高视频质量, 但也会增加网络带宽和 CPU 开销。 <br><br>如果遇到视频卡顿问题, 您可以尝试降低该数值。",
 
         "Settings.PostProcessingSettings": "后期处理",
         "Settings.PostProcessingSettings.MotionBlurIntensity": "动态模糊强度",


### PR DESCRIPTION
Translation is ready. Activity is synced to VRCD-Resonite Department.
For maintainers:
Be aware that some people didn't locale properly for the world Resolution.
In Bilibili and Youtube, resolution or any words about quality of the videos should be “清晰度” or “画质”. Apparently they have not checked for that one.
<img width="2700" height="1224" alt="Screenshot_20260902_122529_tv_danmaku_bili_Unite" src="https://github.com/user-attachments/assets/aab22497-2e84-4111-a28a-92bae130eead" />
<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/769ab3e9-c1f8-4828-a847-376a51af6bc2" />
Following Bilibili, using the first one is suitable.

致翻译人员：
翻译已经落实，但有些情况得说明一下，如果翻译人员明知在群里却没有沟通，导致翻译不符合本地化的规范（根据VRCD文档库的VRchat简中本地化翻译指南以及官方Github的翻译指南），维护人员是可以拒绝翻译的。这个Resolution单词词但凡看过B站或者油管也不至于翻译成分辨率。