### PR TITLE
zh-cn: update some translations

### DIFF
--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1744,7 +1744,7 @@
         "Settings.AudioPerformanceSettings.MaxVoices": "最大同时播放声音数",
         "Settings.AudioPerformanceSettings.MaxVoices.Description": "这控制着可同时播放的声音数量。增加此数值可让您一次听到更多声音, 但会以增加 CPU 使用率为代价。<br><br>如果把数值设置太高, 您有可能会听到爆音。",
         "Settings.AudioPerformanceSettings.OutputBufferSize": "播放缓冲区大小",
-        "Settings.AudioPerformanceSettings.OutputBufferSize.Description": "此设置控制音频播放缓冲区的大小。<br><br>数值基于您电脑音频缓冲区大小的倍数 - 缓冲区大小通常被称为您电脑音频的“处理块(quantum)”。<br><br>数值越大, 音频延迟越高, 但更能避免爆音和杂音。<br><br>降低此值可减少音频延迟, 但系统将更容易出现爆音和音频中断。",
+        "Settings.AudioPerformanceSettings.OutputBufferSize.Description": "此设置控制音频播放缓冲区的大小。<br><br>该值以您的计算机音频缓冲区大小为基准，按整数倍分级缩放——该基准大小常被称为计算机音频的 \"quantum\" (最小处理块)。<br><br>数值越大, 音频延迟越高, 但更能避免爆音和杂音。<br><br>降低此值可减少音频延迟, 但系统将更容易出现爆音和音频中断。",
         "Settings.AudioPerformanceSettings.SimulationFramesPerBuffer": "每个系统缓冲区的模拟帧数",
         "Settings.AudioPerformanceSettings.SimulationFramesPerBuffer.Description": "此设置控制在您的电脑音频缓冲区大小（又称电脑音频的“处理块(quantum)”）周期，模拟器将运行多少次。 <br><br><color=hero.orange><b><i>重要提示</b></color>：</i>这与播放缓冲区大小<i>无关</i>。它仅与您电脑音频的处理块有关。 <br><br>例如：如果您电脑的处理块大小为960个采样，而模拟器在该周期内以4帧进行模拟，那么模拟器每次将渲染240个音频采样。 <br><br>对于大多数系统而言，设置为“4”应该就足够了。",
 

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -1744,7 +1744,7 @@
         "Settings.AudioPerformanceSettings.MaxVoices": "最大同时播放声音数",
         "Settings.AudioPerformanceSettings.MaxVoices.Description": "这控制着可同时播放的声音数量。增加此数值可让您一次听到更多声音, 但会以增加 CPU 使用率为代价。<br><br>如果把数值设置太高, 您有可能会听到爆音。",
         "Settings.AudioPerformanceSettings.OutputBufferSize": "播放缓冲区大小",
-        "Settings.AudioPerformanceSettings.OutputBufferSize.Description": "此设置控制音频播放缓冲区的大小。数值越大, 音频延迟越高, 但更能避免爆音和杂音。<br><br>降低此值可减少音频延迟, 但系统将更容易出现爆音和音频中断。",
+        "Settings.AudioPerformanceSettings.OutputBufferSize.Description": "此设置控制音频播放缓冲区的大小。<br><br>数值基于您电脑音频缓冲区大小的倍数 - 缓冲区大小通常被称为您电脑音频的“处理块(quantum)”。<br><br>数值越大, 音频延迟越高, 但更能避免爆音和杂音。<br><br>降低此值可减少音频延迟, 但系统将更容易出现爆音和音频中断。",
         "Settings.AudioPerformanceSettings.SimulationFramesPerBuffer": "每个系统缓冲区的模拟帧数",
         "Settings.AudioPerformanceSettings.SimulationFramesPerBuffer.Description": "此设置控制在您的电脑音频缓冲区大小（又称电脑音频的“处理块(quantum)”）周期，模拟器将运行多少次。 <br><br><color=hero.orange><b><i>重要提示</b></color>：</i>这与播放缓冲区大小<i>无关</i>。它仅与您电脑音频的处理块有关。 <br><br>例如：如果您电脑的处理块大小为960个采样，而模拟器在该周期内以4帧进行模拟，那么模拟器每次将渲染240个音频采样。 <br><br>对于大多数系统而言，设置为“4”应该就足够了。",
 

--- a/zh-cn.json
+++ b/zh-cn.json
@@ -2834,7 +2834,7 @@
         "Temporary.MMC.VoteInvalid": "无效投票, 请重试。",
 
         "CloudHome.WelcomeHome": "欢迎回家",
-        "CloudHome.TargetRangeOptions": "目标范围选项",
+        "CloudHome.TargetRangeOptions": "靶场选项",
 
         "Tutorial.Saving.Title": "欢迎回家！",
         "Tutorial.Saving.Content": "欢迎来到您的 <b><i><color=hero.yellow>家园</b></i></color> 世界！这是您每次登录后所来到的地方。<br><br>这是一个您自己的世界, 您可以保存任何所作的更改。<br><br>如果您保存了, 当您下次回来时, 一切将与您离开时一模一样！",


### PR DESCRIPTION
Regarding TargetRangeOptions, it seems to be the "Shooting Range" inside the default Cloud Home.

<img width="2658" height="1501" alt="image" src="https://github.com/user-attachments/assets/470d7456-df4b-46aa-99d4-5597441329ef" />

Regarding OutputBufferSize.Description, the content was updated in the commit a68d32c30f153d9f059e05694671760908d52475

Requesting @modimobeikete @ZokuTe for comments and approval.